### PR TITLE
fix: update examples for close and onUrlOpen handlers

### DIFF
--- a/versioned_docs/version-3.0/android-handle-paywall-actions.md
+++ b/versioned_docs/version-3.0/android-handle-paywall-actions.md
@@ -17,7 +17,7 @@ If you are building paywalls using the Adapty paywall builder, it's crucial to s
 This guide shows how to handle custom and pre-existing actions in your code.
 
 :::warning
-**Only purchases and restorations are handled automatically.** All the other button actions, such as closing paywalls or opening links, require implementing proper responses in the app code.
+**Only purchases, restorations, paywall closures, and URL opening are handled automatically.** All other button actions require proper response implementation in the app code.
 :::
 
 ## Close paywalls

--- a/versioned_docs/version-3.0/handle-paywall-actions.md
+++ b/versioned_docs/version-3.0/handle-paywall-actions.md
@@ -17,7 +17,7 @@ If you are building paywalls using the Adapty paywall builder, it's crucial to s
 This guide shows how to handle custom and pre-existing actions in your code.
 
 :::warning
-**Only purchases and restorations are handled automatically.** All the other button actions, such as closing paywalls or opening links, require implementing proper responses in the app code.
+**Only purchases, restorations, paywall closures, and URL opening are handled automatically.** All other button actions require proper response implementation in the app code.
 :::
 
 ## Close paywalls
@@ -28,7 +28,7 @@ To add a button that will close your paywall:
 2. In your app code, implement a handler for the `close` action that dismisses the paywall.
 
 :::info
-In the iOS, Android SDK, the `close` action triggers closing the paywall by default. However, you can override this behavior in your code if needed. For example, closing one paywall might trigger opening another.
+In the iOS SDK, the `close` action triggers closing the paywall by default. However, you can override this behavior in your code if needed. For example, closing one paywall might trigger opening another.
 :::
 
 

--- a/versioned_docs/version-3.0/react-native-handle-paywall-actions.md
+++ b/versioned_docs/version-3.0/react-native-handle-paywall-actions.md
@@ -17,7 +17,7 @@ If you are building paywalls using the Adapty paywall builder, it's crucial to s
 This guide shows how to handle custom and pre-existing actions in your code.
 
 :::warning
-**Only purchases and restorations are handled automatically.** All the other button actions, such as closing paywalls or opening links, require implementing proper responses in the app code.
+**Only purchases, restorations, paywall closures, and URL opening are handled automatically.** All other button actions require proper response implementation in the app code.
 :::
 
 ## Close paywalls

--- a/versioned_docs/version-3.0/react-native-quickstart-paywalls.md
+++ b/versioned_docs/version-3.0/react-native-quickstart-paywalls.md
@@ -95,11 +95,11 @@ For more details on how to display a paywall, see our [guide](react-native-prese
 
 ## 3. Handle button actions
 
-When users click buttons in the paywall, the React Native SDK automatically handles purchases, restoration, and closing the paywall.
+When users click buttons in the paywall, the React Native SDK automatically handles purchases, restoration, closing the paywall, and opening URLs.
 
 However, other buttons have custom or pre-defined IDs and require handling actions in your code. Or, you may want to override their default behavior.
 
-For example, you will definitely need to support opening links when users tap them.
+For example, here is the default behavior for the close button. You don't need to add it in the code, but here, you can see how it is done if needed.
 
 :::tip
 Read our guides on how to handle button [actions](react-native-handle-paywall-actions.md) and [events](react-native-handling-events-1.md).
@@ -107,10 +107,9 @@ Read our guides on how to handle button [actions](react-native-handle-paywall-ac
 
 ```typescript showLineNumbers title="React Native"
 const unsubscribe = view.registerEventHandlers({
-    onUrlPress(url) {
-      Linking.openURL(url);
-      return false;
-  },
+    onCloseButtonPress() {
+        return true; // allow paywall closing
+    }
 });
 ```
 
@@ -142,9 +141,8 @@ export default function PaywallScreen() {
       const view = await createPaywallView(paywall);
 
       view.registerEventHandlers({
-          onUrlPress(url) {
-              Linking.openURL(url);
-              return false;
+          onCloseButtonPress() {
+              return true;
         },
       });
 


### PR DESCRIPTION
We return true to allow paywall closing so we dont need  view.dismiss()
https://adapty.io/docs/react-native-handle-paywall-actions