### PR TITLE
ci(translate): retry push with rebase on race

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -224,6 +224,11 @@ jobs:
       # Commit any new or updated locale files back to main. This push
       # triggers s3-deploy-production.yml, so the deploy that follows will
       # include the freshly translated content.
+      #
+      # Push is retried with rebase to recover from the common race where
+      # another commit lands on main while translation is in flight (the
+      # workflow can run 5–10 min). Without this, the push is rejected and
+      # the run has to be re-applied manually.
       - name: Commit updated translations
         run: |
           git config user.name "github-actions[bot]"
@@ -231,10 +236,20 @@ jobs:
           git add src/locales/
           if git diff --staged --quiet; then
             echo "No translation changes to commit."
-          else
-            git commit -m "chore: update translations"
-            git push
+            exit 0
           fi
+          git commit -m "chore: update translations"
+          for attempt in 1 2 3 4 5; do
+            git pull --rebase origin main
+            if git push; then
+              echo "Pushed translations on attempt $attempt."
+              exit 0
+            fi
+            echo "Push attempt $attempt rejected; will rebase and retry."
+            sleep $((RANDOM % 10 + 5))
+          done
+          echo "Failed to push translations after 5 attempts."
+          exit 1
 
       # If lint or commit failed, preserve the aggregated locale state for
       # manual recovery. The per-locale `failed-*` artifacts from the matrix


### PR DESCRIPTION
## Summary
- The translate workflow's final `git push` has no rebase or retry, so if any commit lands on `main` during the 5–10 minute translation run, the push is rejected (`! [rejected] main -> main (fetch first)`) and the whole batch has to be re-applied manually from the failure artifact.
- This adds a 5-attempt `pull --rebase` + `push` loop with a short jittered sleep between attempts, plus an explicit non-zero exit if all attempts fail.
- See [run 26168025182](https://github.com/adaptyteam/adapty-docs/actions/runs/26168025182/job/76979267294) for the failure mode this fixes.

## Test plan
- [ ] Next translate run merges cleanly (no race expected) — confirm no behavior change in the happy path.
- [ ] If a race happens, confirm logs show the rebase + retry and the push lands on a later attempt.