### PR TITLE
Remove beta framing from React Native SDK v4 docs

### DIFF
--- a/scripts/generate-md.mjs
+++ b/scripts/generate-md.mjs
@@ -118,12 +118,8 @@ function stripContent(content, reusableComponents) {
 > This feature has two SDK paradigms. Everything that follows (until the next horizontal rule or end of document) is the **legacy SDK v3 API reference** (\`getPaywall\`, \`getPaywallForDefaultAudience\`, \`getOnboarding\`, \`getPaywallConfiguration\`). The **SDK v4+ \`getFlow\` method is documented above.** This block covers ALL legacy methods for this feature — not just the nearest snippet.
 >
 > **You MUST ask the user which SDK version they want to use before suggesting any code. Do not assume or default to a version.** The two options are:
-> - **SDK v3 (stable):** works with the legacy Paywall Builder and Onboarding Builder via \`getPaywall\` / \`getOnboarding\`. Use the legacy code in this section.
-> - **SDK v4 (beta):** works with BOTH the new Flow Builder AND legacy paywalls/onboardings via the unified \`getFlow\` method documented above.
->
-> **If the user chooses the v4 beta, warn them that Adapty iOS SDK 4.0 is a pre-release.** Swift Package Manager does not resolve beta versions through the **Up to Next Major Version** (\`from:\`) rule, so they must pin the exact version:
-> - In Xcode, set the **Dependency Rule** to **Exact Version** and enter \`4.0.0-beta.1\`.
-> - In \`Package.swift\`, use \`.exact("4.0.0-beta.1")\`.
+> - **SDK v3 (legacy):** works with the legacy Paywall Builder and Onboarding Builder via \`getPaywall\` / \`getOnboarding\`. Use the legacy code in this section.
+> - **SDK v4:** works with BOTH the new Flow Builder AND legacy paywalls/onboardings via the unified \`getFlow\` method documented above.
 >
 > Apply the legacy v3 code in this section ONLY when:
 > 1. The user explicitly chose **SDK v3**, or

--- a/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
+++ b/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
@@ -259,7 +259,15 @@ The flat Android subscription-update shape is removed. Move `oldSubVendorProduct
 
 ### Android: safe-area paddings
 
-The Android boolean resource `<bool name="adapty_paywall_enable_safe_area_paddings">…</bool>` is removed. Delete it from `res/values/bools.xml` and control safe-area paddings at runtime with the `enableSafeArea` parameter when you create the flow view. It defaults to `true` for modal presentation and `false` for the embedded component.
+The Android boolean resource `<bool name="adapty_paywall_enable_safe_area_paddings">…</bool>` is removed. Delete it from `res/values/bools.xml` and control safe-area paddings at runtime with the `android.enableSafeArea` parameter when you create the flow view. It defaults to `true` for modal presentation and `false` for the embedded component:
+
+```typescript showLineNumbers
+const view = await createFlowView(flow, {
+  android: {
+    enableSafeArea: false,
+  },
+});
+```
 
 ### Mock mode
 

--- a/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
+++ b/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Migrate Adapty React Native SDK to v. 4.0"
-description: "Migrate to Adapty React Native SDK v4.0 (beta) by replacing paywall APIs with flow APIs, compatible with both Flow Builder and Paywall Builder."
-metadataTitle: "Migrating to Adapty React Native SDK v4.0 (beta) | Adapty Docs"
+description: "Migrate to Adapty React Native SDK v4.0 by replacing paywall APIs with flow APIs, compatible with both Flow Builder and Paywall Builder."
+metadataTitle: "Migrating to Adapty React Native SDK v4.0 | Adapty Docs"
 ---
 
-Adapty React Native SDK 4.0 (beta) introduces flows and renames the paywall APIs accordingly. The new APIs work with both the new Flow Builder and the existing Paywall Builder — no setup changes are required on the Adapty Dashboard side.
+Adapty React Native SDK 4.0 introduces flows and renames the paywall APIs accordingly. The new APIs work with both the new Flow Builder and the existing Paywall Builder — no setup changes are required on the Adapty Dashboard side.
 
 ## Quick reference
 
@@ -32,12 +32,12 @@ Adapty React Native SDK 4.0 raises the minimum iOS deployment target from iOS 13
 
 ### Update the package
 
-v4.0 is a pre-release, so pin the exact version — npm does not select pre-release versions through caret/tilde ranges:
+Update `react-native-adapty` to v4.0:
 
 ```bash showLineNumbers
-npm install react-native-adapty@4.0.0-beta.1
+npm install react-native-adapty@^4.0.0
 # or
-yarn add react-native-adapty@4.0.0-beta.1
+yarn add react-native-adapty@^4.0.0
 ```
 
 ### iOS: native SDKs now come through Swift Package Manager

--- a/src/content/docs/react-native/react-native-get-pb-paywalls.mdx
+++ b/src/content/docs/react-native/react-native-get-pb-paywalls.mdx
@@ -92,7 +92,7 @@ Parameters:
 | **flow**             | required | An `AdaptyFlow` object to obtain a controller for the desired flow/paywall. |
 | **customTags**       | optional | Define a dictionary of custom tags and their resolved values. Custom tags serve as placeholders in the content, dynamically replaced with specific strings for personalized content within the flow/paywall. Refer to Custom tags in paywall builder topic for more details. |
 | **prefetchProducts** | optional | Enable to optimize the display timing of products on the screen. When `true` AdaptyUI will automatically fetch the necessary products. Default: `false`. |
-| **enableSafeArea**   | optional | Android only (ignored on iOS). When `true`, the flow view applies safe-area paddings. Defaults to `true` for modal presentation (`createFlowView` + `present()`) and `false` for the embedded `AdaptyFlowView` component. The default is suitable for most cases. |
+| **android.enableSafeArea** | optional | Android only (ignored on iOS). Pass it as a nested object: `android: { enableSafeArea: true }`. When `true`, the flow view applies safe-area paddings. Defaults to `true` for modal presentation (`createFlowView` + `present()`) and `false` for the embedded `AdaptyFlowView` component. The default is suitable for most cases. |
 
 :::note
 If you are using multiple languages, learn how to add a [flow localization](add-paywall-locale-in-adapty-paywall-builder) and how to use locale codes correctly [here](react-native-localizations-and-locale-codes).

--- a/src/content/docs/react-native/react-native-sdk-migration-guides.mdx
+++ b/src/content/docs/react-native/react-native-sdk-migration-guides.mdx
@@ -6,7 +6,7 @@ metadataTitle: "React Native SDK Migration Guides | Adapty Docs"
 
 This page contains all migration guides for Adapty React Native SDK. Choose the version you want to migrate to for detailed instructions:
 
-- **[Migrate to v4.0 (beta)](migration-to-react-native-sdk-v4)**
+- **[Migrate to v4.0](migration-to-react-native-sdk-v4)**
 - **[Migrate to v3.14](migration-react-native-314)**
 - **[Migrate to v3.8](react-native-migration-guide-380)** 
 - **[Migrate to v3.4](migration-to-react-native-sdk-34)** 

--- a/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
@@ -52,7 +52,7 @@ Starting from SDK v3.17, Adapty SDK uses Google Play Billing Library v8.0.0 by d
 ## Install Adapty SDK
 
 :::important
-Starting from v4, the Adapty React Native SDK no longer supports CocoaPods installation of its native dependencies. If you need v4 or later (for the [Flow Builder](adapty-flow-builder)), follow [Adapty SDK 4.0 (beta): enable Swift Package Manager](#adapty-sdk-40-beta-enable-swift-package-manager) below instead.
+Starting from v4, the Adapty React Native SDK no longer supports CocoaPods installation of its native dependencies. If you need v4 or later (for the [Flow Builder](adapty-flow-builder)), follow [Adapty SDK 4.0: enable Swift Package Manager](#adapty-sdk-40-enable-swift-package-manager) below instead.
 :::
 
 [![Release](https://img.shields.io/github/v/release/adaptyteam/AdaptySDK-React-Native.svg?style=flat&logo=react)](https://github.com/adaptyteam/AdaptySDK-React-Native/releases)
@@ -96,12 +96,12 @@ Expo Go doesn't support custom native modules, so you can only use it with [**mo
    npx expo start --dev-client
    ```
 
-### Adapty SDK 4.0 (beta): enable Swift Package Manager
+### Adapty SDK 4.0: enable Swift Package Manager
 
-React Native SDK 4.0 — which adds [Flow Builder](adapty-flow-builder) support — is a pre-release that requires **React Native 0.75 or later**. Install the exact version (npm doesn't resolve pre-releases through caret/tilde ranges):
+React Native SDK 4.0 — which adds [Flow Builder](adapty-flow-builder) support — requires **React Native 0.75 or later**. Install the SDK:
 
 ```sh
-npx expo install react-native-adapty@4.0.0-beta.1
+npx expo install react-native-adapty@^4.0.0
 ```
 
 v4 pulls the native iOS SDKs (`Adapty`, `AdaptyUI`, `AdaptyPlugin`) through Swift Package Manager instead of CocoaPods sub-dependencies ([CocoaPods' spec repo goes read-only in December 2026](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)). SPM requires dynamic frameworks, which in Expo you enable with the [`expo-build-properties`](https://docs.expo.dev/versions/latest/sdk/build-properties/) plugin. Add it to `app.json` (or `app.config.js`):

--- a/src/content/docs/version-3.0/sdk-installation-react-native-pure.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-pure.mdx
@@ -42,7 +42,7 @@ Starting from SDK v3.17, Adapty SDK uses Google Play Billing Library v8.0.0 by d
 ## Install Adapty SDK
 
 :::important
-Starting from v4, the Adapty React Native SDK no longer supports CocoaPods installation of its native dependencies. If you need v4 or later (for the [Flow Builder](adapty-flow-builder)), follow [Adapty SDK 4.0 (beta): enable Swift Package Manager](#adapty-sdk-40-beta-enable-swift-package-manager) below instead.
+Starting from v4, the Adapty React Native SDK no longer supports CocoaPods installation of its native dependencies. If you need v4 or later (for the [Flow Builder](adapty-flow-builder)), follow [Adapty SDK 4.0: enable Swift Package Manager](#adapty-sdk-40-enable-swift-package-manager) below instead.
 :::
 
 [![Release](https://img.shields.io/github/v/release/adaptyteam/AdaptySDK-React-Native.svg?style=flat&logo=react)](https://github.com/adaptyteam/AdaptySDK-React-Native/releases)
@@ -79,15 +79,15 @@ Update the `/android/build.gradle` file. Make sure there is the `kotlin-gradle-p
 
 </details>
 
-### Adapty SDK 4.0 (beta): enable Swift Package Manager
+### Adapty SDK 4.0: enable Swift Package Manager
 
-React Native SDK 4.0 — which adds [Flow Builder](adapty-flow-builder) support — is a pre-release that requires **React Native 0.75 or later**. Install the exact version (npm doesn't resolve pre-releases through caret/tilde ranges):
+React Native SDK 4.0 — which adds [Flow Builder](adapty-flow-builder) support — requires **React Native 0.75 or later**. Install the SDK:
 
 ```sh showLineNumbers title="Shell"
-npm install react-native-adapty@4.0.0-beta.1
+npm install react-native-adapty@^4.0.0
 
 # or using yarn
-yarn add react-native-adapty@4.0.0-beta.1
+yarn add react-native-adapty@^4.0.0
 ```
 
 v4 pulls the native iOS SDKs (`Adapty`, `AdaptyUI`, `AdaptyPlugin`) through Swift Package Manager instead of CocoaPods sub-dependencies ([CocoaPods' spec repo goes read-only in December 2026](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)). SPM requires dynamic frameworks — add the following to your `ios/Podfile` target, then reinstall pods:


### PR DESCRIPTION
## What changed

Prepares the React Native docs for the public (non-beta) release of RN SDK v4, mirroring the iOS/Android beta removal on `v4-full-release`:

- **`migration-to-react-native-sdk-v4.mdx`** — removed "(beta)" from the description, metadata title, and intro; the package-update step no longer says v4 is a pre-release that must be pinned and now installs `react-native-adapty@^4.0.0`.
- **`sdk-installation-react-native-expo.mdx` / `sdk-installation-react-native-pure.mdx`** — renamed the "Adapty SDK 4.0 (beta): enable Swift Package Manager" section (and its in-page anchor link) to drop "(beta)"; removed the pre-release/exact-version-pinning wording; install commands changed from `@4.0.0-beta.1` to `@^4.0.0`.
- **`react-native-sdk-migration-guides.mdx`** — "Migrate to v4.0 (beta)" → "Migrate to v4.0".
- **`scripts/generate-md.mjs`** — the LLM instruction block injected into `.md` exports for pages with `<SDKv3>` wrappers no longer labels SDK v4 as beta or tells LLMs to pin `4.0.0-beta.1`; "SDK v3 (stable)" is now "SDK v3 (legacy)".

## Notes for reviewers

- Deliberately untouched: "skill is in beta" in `adapty-sdk-integration-skill-react-native.mdx` (the integration skill's own beta) and all Flows (Beta) mentions — Flows remain in beta; only the SDK is released.
- RN onboarding articles already carry a beta-free deprecation warning pointing to flows, so they needed no changes.
- The same `generate-md.mjs` fix is still needed on `v4-full-release` — it affects iOS `.md` exports too.
- Validated with `check-mdx-parse`, `lint-mdx`, and the link checker in diff mode (0 broken links, including incoming links to the renamed anchors).
- Merge when RN SDK v4 is published to npm as `latest` (install instructions rely on normal caret resolution).