### PR TITLE
Include category-articles in llms.txt and platform llms-full aggregates

### DIFF
--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -74,7 +74,10 @@ function extractDescription(content) {
 function collectDocIds(items, ids) {
     for (const item of items) {
         if (item.type === 'category') {
+            // A category can BE an article two ways: docusaurus-style
+            // link {type:'doc'} or our sidebar shorthand - a bare `id`.
             if (item.link && item.link.type === 'doc') ids.add(item.link.id);
+            else if (item.id) ids.add(item.id);
             if (item.items) collectDocIds(item.items, ids);
         } else if (item.type === 'doc' && item.id) {
             ids.add(item.id);
@@ -288,11 +291,13 @@ function parseItems(items, ctx, depth = 0) {
                 }
             }
 
-            // If category has a link, add it as a doc item too
-            if (item.link && item.link.type === 'doc') {
-                const desc = descriptions.get(item.link.id);
+            // If the category itself is an article (docusaurus link {type:'doc'}
+            // or our sidebar shorthand - a bare `id`), add it as a doc item too.
+            const categoryDocId = item.link && item.link.type === 'doc' ? item.link.id : item.id;
+            if (categoryDocId) {
+                const desc = descriptions.get(categoryDocId);
                 const suffix = desc ? `: ${desc}` : '';
-                output += `${indent}  - [Overview](${BASE_URL}${urlPrefix}/${item.link.id}.md)${suffix}\n`;
+                output += `${indent}  - [Overview](${BASE_URL}${urlPrefix}/${categoryDocId}.md)${suffix}\n`;
             }
 
             // Process children

--- a/scripts/generate-platform-llms-full.mjs
+++ b/scripts/generate-platform-llms-full.mjs
@@ -161,9 +161,12 @@ function cleanFrontmatter(content) {
 function extractDocIds(items, docIds = []) {
     for (const item of items) {
         if (item.type === 'category') {
-            // If category has a link, add it
+            // If the category itself is an article (docusaurus link {type:'doc'}
+            // or our sidebar shorthand - a bare `id`), add it.
             if (item.link && item.link.type === 'doc') {
                 docIds.push(item.link.id);
+            } else if (item.id) {
+                docIds.push(item.id);
             }
             // Process children
             if (item.items) {


### PR DESCRIPTION
## Problem

Our sidebar JSONs mark an article-category two ways: docusaurus-style `link: {type: 'doc', id}` and a shorthand — a bare `id` on the category itself (`{type: 'category', id: 'quickstart', items: [...]}`). Both llms generators only understood the `link` form and silently skipped the shorthand.

**Impact: 84 pages were invisible to agents** — absent from `llms.txt` (so agents can't discover them) and their content missing from every `<platform>-llms-full.txt` aggregate (so agents can't fetch them in bulk either). The list includes load-bearing pages: `flutter-paywalls`, `ios-reference`, `placements`, `product`, `webhook`, `attribution-integration`, `what-is-adapty`, `quickstart`, the ads-manager section, and the per-platform overview/reference/migration category pages.

Found by the new link lint in adapty-sdk-integration-skill (it flagged skill-referenced pages as 'works but not discoverable via llms.txt').

## Fix

Three spots, one idea — a category with a bare `id` IS an article:

1. `generate-llms.mjs` / `collectDocIds` — shorthand ids join the description map
2. `generate-llms.mjs` / `parseItems` — shorthand categories emit their `[Overview](…)` line, same as link-form ones
3. `generate-platform-llms-full.mjs` / `extractDocIds` — their content lands in the aggregates

## Verification (local generator runs)

- `llms.txt`: 638 → **722** page links (+84 — matches the sidebar scan one-to-one)
- `quickstart`, `initial-android`, `flutter-paywalls`, `placements`, `webhook` present in the index
- `flutter-paywalls` content present in `flutter-llms-full.txt`
- localized indexes (ja/zh/vi/…) regenerate through the same code path