### PR TITLE
Document Stripe and Paddle store bindings in products create

### DIFF
--- a/src/content/docs/developer-cli/developer-cli-quickstart.mdx
+++ b/src/content/docs/developer-cli/developer-cli-quickstart.mdx
@@ -103,7 +103,7 @@ You'll need the product IDs from each store: the Apple product ID from App Store
 If you skipped step 4, use the `default_access_level.id` returned by the `apps create` command in step 3 as your `<access-level-id>`.
 
 :::important
-The store product IDs you link here (`--ios-product-id`, `--android-product-id`) cannot be changed after creation. To use different store product IDs, create a new product.
+The store product IDs you link here cannot be changed after creation. To use different store product IDs, create a new product.
 :::
 
 <Tabs>
@@ -125,6 +125,8 @@ The store product IDs you link here (`--ios-product-id`, `--android-product-id`)
 </Tabs>
 
 The command returns a `<product-id>`.
+
+If you also sell this product on the web through Stripe or Paddle, add those IDs to the same command. See [products create](developer-cli-reference#adapty-products-create) in the full reference.
 
 ## 6. Create a paywall
 

--- a/src/content/docs/developer-cli/developer-cli-reference.mdx
+++ b/src/content/docs/developer-cli/developer-cli-reference.mdx
@@ -194,7 +194,7 @@ adapty products get --app <app-id> <product-id>
 Create a new [product](product).
 
 :::important
-The store product IDs (`--ios-product-id`, `--android-product-id`, `--android-base-plan-id`) cannot be changed after creation. To use different store product IDs, create a new product.
+The store product and price IDs cannot be changed after creation. To use different store IDs, create a new product.
 :::
 
 ```bash
@@ -207,15 +207,29 @@ adapty products create --app <app-id> --title "Monthly" --access-level-id <acces
 | `--title` | Yes | Product title |
 | `--access-level-id` | Yes | [Access level](access-level) ID (UUID) this product unlocks |
 | `--period` | Yes | Subscription period: `weekly`, `monthly`, `two_months`, `trimonthly`, `semiannual`, `annual`, `lifetime` |
-| `--ios-product-id` | At least one platform required | Product ID from App Store Connect |
-| `--android-product-id` | At least one platform required | Product ID from Google Play Console |
+| `--ios-product-id` | At least one store required | Product ID from App Store Connect |
+| `--android-product-id` | At least one store required | Product ID from Google Play Console |
 | `--android-base-plan-id` | Required with `--android-product-id` unless `--period lifetime` | Base plan ID from Google Play Console |
+| `--stripe-product-id` | At least one store required | Product ID from Stripe |
+| `--stripe-price-id` | Required with `--stripe-product-id` | Price ID from Stripe |
+| `--paddle-product-id` | At least one store required | Product ID from Paddle |
+| `--paddle-price-id` | Required with `--paddle-product-id` | Price ID from Paddle |
+
+Every product needs at least one store: `--ios-product-id`, `--android-product-id`, `--stripe-product-id`, or `--paddle-product-id`. A single product can carry IDs for several stores at once.
+
+To sell a product on the web through Stripe or Paddle, connect the payment provider to Adapty first: see [Stripe](stripe) and [Paddle](paddle). For each of these stores, pass the product ID and the price ID together. The command fails if you pass only one of the pair.
+
+```bash
+adapty products create --app <app-id> --title "Monthly" --access-level-id <access-level-id> --period monthly --stripe-product-id prod_xxx --stripe-price-id price_xxx
+```
+
+A web-only product is valid: you can create a product with Stripe or Paddle IDs and no App Store or Google Play IDs.
 
 ### adapty products update
 
 Update an existing [product](product).
 
-Store product IDs (`--ios-product-id`, `--android-product-id`) cannot be changed after creation and are not available in this command. To use different store product IDs, create a new product.
+Store product and price IDs cannot be changed after creation and are not available in this command. To use different store IDs, create a new product.
 
 ```bash
 adapty products update --app <app-id> <product-id> --title "Monthly" --access-level-id <access-level-id>


### PR DESCRIPTION
Documents the new web store bindings from [adapty-cli#6](https://github.com/adaptyteam/adapty-cli/pull/6): `--stripe-product-id`/`--stripe-price-id` and `--paddle-product-id`/`--paddle-price-id` on `adapty products create`.

## Changes

**Full reference** — `adapty products create`:
- Four new flag rows.
- "At least one platform required" → "At least one store required", plus a sentence naming the four store flags.
- A paragraph on web products: connect Stripe/Paddle to Adapty first, pass product ID and price ID together, the command fails on a lone flag.
- A Stripe example command, and a note that a web-only product is valid.
- Immutability callout generalized — it listed only the mobile flags.
- Same generalization in the `products update` note.

**Quickstart** — kept mobile-first, since `apps create` only accepts `--platform ios|android`. Generalized the immutability callout and added one line pointing to the reference for Stripe/Paddle IDs.
