### PR TITLE
Add Android app links alongside iOS app links

### DIFF
--- a/src/content/docs/guides/flow-builder/migrate-to-flows.mdx
+++ b/src/content/docs/guides/flow-builder/migrate-to-flows.mdx
@@ -81,7 +81,7 @@ Building a flow from a ready-made flow template or generating one with AI isn't 
 
 ### Preview on device
 
-You can preview the flow on a real device without touching the app. Download the [Adapty app](https://apps.apple.com/us/app/adapty/id6739359219) from the App Store. Then, in the flow builder, click **Test on device**, choose a locale, and scan the QR code with your device. This shows the real screens, branching, copy, and design.
+You can preview the flow on a real device without touching the app. Download the Adapty mobile app for [iOS](https://apps.apple.com/us/app/adapty/id6739359219) or [Android](https://play.google.com/store/apps/details?id=io.adapty.dashboard). Then, in the flow builder, click **Test on device**, choose a locale, and scan the QR code with your device. This shows the real screens, branching, copy, and design.
 
 :::note
 In the preview mode, Adapty can't reach your products in the stores, so the prices shown in the preview aren't real. Real purchases are verified later, in the v4 build with a sandbox account — see [Update the SDK](#update-the-sdk).

--- a/src/content/docs/version-3.0/paywall-device-compatibility-preview.mdx
+++ b/src/content/docs/version-3.0/paywall-device-compatibility-preview.mdx
@@ -15,7 +15,7 @@ You have two ways to preview your flow on different screen types:
 
 To preview your flow on a real device:
 
-1. [Download the Adapty app from the App Store](https://apps.apple.com/us/app/adapty/id6739359219).
+1. Download the Adapty mobile app for [iOS](https://apps.apple.com/us/app/adapty/id6739359219) or [Android](https://play.google.com/store/apps/details?id=io.adapty.dashboard).
 2. In the flow builder, click **Test on device**.
 
 <ZoomImage id="flow-test-on-device.webp" width="700px" alt="Test on device button in the flow builder" />

--- a/src/content/docs/version-3.0/push-notifications.mdx
+++ b/src/content/docs/version-3.0/push-notifications.mdx
@@ -5,7 +5,7 @@ metadataTitle: "Adapty events Push notifications | Adapty Docs"
 ---
 import ZoomImage from '@site/src/components/ZoomImage';
 
-Push notifications in the [Adapty iOS app](https://apps.apple.com/us/app/adapty/id6739359219) help you stay updated on what's happening with your apps in real time. Whether you're tracking new trials, subscription renewals, or installs, you'll get instant updates without checking the dashboard.
+Push notifications in the Adapty mobile app for [iOS](https://apps.apple.com/us/app/adapty/id6739359219) and [Android](https://play.google.com/store/apps/details?id=io.adapty.dashboard) help you stay updated on what's happening with your apps in real time. Whether you're tracking new trials, subscription renewals, or installs, you'll get instant updates without checking the dashboard.
 
 You can set default notification settings that apply to all apps, and then adjust them for specific apps if you need more control. This is especially useful when you're launching a new app and want to monitor early activity closely.
 
@@ -13,7 +13,7 @@ The total number of notifications for all your apps combined is limited to 1000/
 
 ## Configure Push notifications
 
-To configure push notifications in the Adapty iOS app:
+To configure push notifications in the Adapty mobile app:
 
 1. Open the Adapty app.
 2. Go to **Settings → Notifications**.

--- a/src/data/sidebars/tutorial.json
+++ b/src/data/sidebars/tutorial.json
@@ -1051,6 +1051,7 @@
         "label": "Discrepancies and troubleshooting"
       },
       {
+        "type": "doc",
         "id": "push-notifications",
         "label": "Get Push notifications about new events"
       }


### PR DESCRIPTION
## What

- Everywhere the docs link the Adapty iOS app ([App Store](https://apps.apple.com/us/app/adapty/id6739359219)), also link the [Android app](https://play.google.com/store/apps/details?id=io.adapty.dashboard) (it has feature parity with iOS):
  - `paywall-device-compatibility-preview.mdx` — download step in "Preview on devices"
  - `migrate-to-flows.mdx` — "Preview on device" section
  - `push-notifications.mdx` — intro; also renamed "Adapty iOS app" → "Adapty mobile app"
- Restore the missing `"type": "doc"` on the push-notifications entry in `tutorial.json` (lost in a merge-conflict resolution; made the sidebar link unclickable)

## Verification

- `check-mdx-parse` + `lint-mdx`: clean
- `check-links-diff`: 0 broken, 0 stale (Play Store URL resolves)
- Audited all 9 sidebar JSONs for other missing-`type` entries — none found