### PR TITLE
Add PostHog tracking for article buttons and scroll depth

### DIFF
--- a/src/components/ArticleButtons.astro
+++ b/src/components/ArticleButtons.astro
@@ -79,6 +79,12 @@ const ti = strings.installTools;
     const container = document.getElementById('article-buttons');
     if (!container) return;
 
+    // Guard against double-binding: this runs both at module eval and on the
+    // initial astro:page-load. After a ClientRouter swap the container is a
+    // fresh element, so the flag is gone and listeners bind again as needed.
+    if (container.dataset.init === '1') return;
+    container.dataset.init = '1';
+
     // Show the buttons (they are hidden by default to avoid flash)
     container.classList.remove('hidden');
 
@@ -136,6 +142,7 @@ const ti = strings.installTools;
         if (mdContent) {
             try {
                 await navigator.clipboard.writeText(mdContent);
+                window.docsTrack?.('docs_copy_for_llm_clicked');
 
                 // Visual Feedback
                 const span = copyBtn.querySelector('span');
@@ -155,6 +162,7 @@ const ti = strings.installTools;
 
     // View Handler
     viewBtn?.addEventListener('click', () => {
+        window.docsTrack?.('docs_view_as_markdown_clicked');
         window.open(mdUrl, '_blank');
     });
   }

--- a/src/components/InstallToolsModal.astro
+++ b/src/components/InstallToolsModal.astro
@@ -304,6 +304,12 @@ const tools = agentTools.tools.map((tool) => ({
         const openBtn = document.getElementById('install-tools-btn');
         if (!modal || !openBtn) return;
 
+        // Guard against double-binding: this runs both at module eval and on
+        // the initial astro:page-load. After a ClientRouter swap the modal is
+        // a fresh element, so the flag is gone and listeners bind again.
+        if (modal.dataset.init === '1') return;
+        modal.dataset.init = '1';
+
         const closeBtn = modal.querySelector<HTMLButtonElement>('.itm-close');
         let lastFocus: HTMLElement | null = null;
 
@@ -312,6 +318,7 @@ const tools = agentTools.tools.map((tool) => ({
             modal!.hidden = false;
             document.body.style.overflow = 'hidden';
             closeBtn?.focus();
+            (window as any).docsTrack?.('docs_install_tools_opened');
         }
 
         function close() {
@@ -361,6 +368,11 @@ const tools = agentTools.tools.map((tool) => ({
                 if (!code) return;
                 try {
                     await navigator.clipboard.writeText(code.textContent ?? '');
+                    // Panel copy buttons report their tool id; the bottom
+                    // usage-command block sits outside any panel.
+                    (window as any).docsTrack?.('docs_install_tool_copied', {
+                        tool: btn.closest<HTMLElement>('.itm-panel')?.dataset.tool ?? 'usage-command',
+                    });
                     btn.classList.add('copied');
                     setTimeout(() => btn.classList.remove('copied'), 2000);
                 } catch (err) {

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -112,7 +112,44 @@ const showHreflang = !isFullWidth && !noindex;
     <script src="https://survey.survicate.com/workspaces/af55d3f51f8189593de1c948b75c88f6/web_surveys.js" async></script>
     </Fragment>
     )}
-    
+
+    <!-- PostHog analytics (loads only on adapty.io; set localStorage docs_ph_debug=1 to enable elsewhere) -->
+    <script is:inline>
+      (function() {
+        var phEnabled = false;
+        try {
+          phEnabled = window.location.hostname === 'adapty.io' || localStorage.getItem('docs_ph_debug') === '1';
+        } catch (e) { /* localStorage unavailable */ }
+
+        if (phEnabled) {
+          !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+          posthog.init('phc_sPU6SMXCehDZKrKaTzAFxFZRbiufWx4Vu4Kh9L8VREjQ', {
+            api_host: 'https://us.i.posthog.com',
+            defaults: '2025-05-24',
+            autocapture: false,
+            capture_pageleave: true
+          });
+        }
+
+        // Shared tracking helper. Stamps every event with page, locale, and
+        // article_id (the slug without the locale prefix — identical across
+        // translations, so one article can be aggregated over all locales).
+        window.docsTrack = function(event, props) {
+          if (!phEnabled || !window.posthog) return;
+          var path = window.location.pathname.replace(/\/$/, '') || '/docs';
+          var localeMatch = path.match(/^\/docs\/([a-z]{2})(\/|$)/);
+          var prefix = localeMatch ? '/docs/' + localeMatch[1] : '/docs';
+          var payload = {
+            page: path,
+            locale: localeMatch ? localeMatch[1] : 'en',
+            article_id: path.slice(prefix.length).replace(/^\//, '') || 'index'
+          };
+          for (var k in props) payload[k] = props[k];
+          window.posthog.capture(event, payload);
+        };
+      })();
+    </script>
+
     <!-- Theme initialization (before page render to avoid flash) -->
     <script is:inline>
       // Initialize theme immediately
@@ -976,9 +1013,13 @@ const showHreflang = !isFullWidth && !noindex;
               copyBtn.onclick = async () => {
                   try {
                       await navigator.clipboard.writeText(pre.textContent || '');
+                      (window as any).docsTrack?.('docs_code_copied', {
+                          language: pre.getAttribute('data-language') || undefined,
+                          title,
+                      });
                       copyBtn.textContent = 'Copied!';
                       copyBtn.classList.add('copied');
-                      
+
                       // Force inline styles for success state (requested by user)
                       if (isDark) {
                           copyBtn.style.setProperty('color', '#a78bfa', 'important'); // Brand purple light
@@ -1102,9 +1143,12 @@ const showHreflang = !isFullWidth && !noindex;
                copyBtn.onclick = async () => {
                   try {
                       await navigator.clipboard.writeText(pre.textContent || '');
+                      (window as any).docsTrack?.('docs_code_copied', {
+                          language: pre.getAttribute('data-language') || undefined,
+                      });
                       copyBtn.textContent = 'Copied!';
                       copyBtn.classList.add('copied');
-                      
+
                       // Force inline styles for success state
                       if (isDark) {
                           copyBtn.style.setProperty('color', '#a78bfa', 'important');
@@ -1600,3 +1644,48 @@ const showHreflang = !isFullWidth && !noindex;
     }
   }
 </style>
+
+<script>
+  // Scroll-depth tracking: fires docs_scroll_depth at 25/50/75/90, each once
+  // per pageview. State resets on ClientRouter navigations (astro:page-load).
+  (function () {
+    const THRESHOLDS = [25, 50, 75, 90];
+    let fired: number[] = [];
+    let ticking = false;
+
+    function check() {
+      ticking = false;
+      const scrollHeight = document.documentElement.scrollHeight;
+      const viewport = window.innerHeight;
+      // Skip hidden/prerendered documents (zero viewport) — the no-scrollbar
+      // shortcut below would otherwise misreport them as fully read.
+      if (viewport === 0) return;
+      // A page with no scrollbar is fully visible — count it as fully read,
+      // so short articles don't look unread in the data.
+      const pct = scrollHeight <= viewport
+        ? 100
+        : ((window.scrollY + viewport) / scrollHeight) * 100;
+      for (const t of THRESHOLDS) {
+        if (pct >= t && !fired.includes(t)) {
+          fired.push(t);
+          (window as any).docsTrack?.('docs_scroll_depth', { depth: t });
+        }
+      }
+    }
+
+    function onScroll() {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(check);
+      }
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    document.addEventListener('astro:page-load', () => {
+      fired = [];
+      check();
+    });
+    check();
+  })();
+</script>


### PR DESCRIPTION
## What

Page-specific, locale-aware PostHog tracking on the docs site:

- **PostHog init** in `DocsLayout.astro` head — loads only on `adapty.io` (or with `localStorage.docs_ph_debug = '1'` for debugging), `autocapture: false`, pageviews via `history_change` so Astro ClientRouter navigations are counted.
- **`window.docsTrack` helper** stamps every event with `page`, `locale` (URL prefix), and `article_id` (slug without locale — aggregates one article across all translations).
- **Events**:
  | Event | Extra props |
  |---|---|
  | `docs_code_copied` | language, block title |
  | `docs_copy_for_llm_clicked` | — |
  | `docs_view_as_markdown_clicked` | — |
  | `docs_install_tools_opened` | — |
  | `docs_install_tool_copied` | tool |
  | `docs_scroll_depth` | depth: 25/50/75/90 |
- Scroll thresholds fire once per pageview and reset on `astro:page-load`; pages with no scrollbar count as fully read; zero-viewport (prerendered/hidden) documents are skipped.
- Copy events fire only after a **successful** clipboard write.

## Bug fix included

`ArticleButtons` and `InstallToolsModal` bound their handlers twice on initial load (module eval + initial `astro:page-load`): View as Markdown opened two tabs, copies ran twice, and events would have double-counted. Both inits now guard with a `dataset.init` flag that naturally resets on ClientRouter swaps.

## Verification

- Verified in-browser: each event fires exactly once with correct `page`/`locale`/`article_id`; scroll dedupe + navigation reset exercised; real-click test confirmed clipboard-gated events send (`[PostHog.js] send "docs_copy_for_llm_clicked"`).
- Ingestion round-trip confirmed — events visible in the PostHog project (US cloud).
- Consumed live by the analytix dashboards (`/scroll`, `/engagement`).