### PR TITLE
Document Paddle support in Amplitude, Mixpanel, and Firebase integrations

### DIFF
--- a/src/content/docs/version-3.0/amplitude.mdx
+++ b/src/content/docs/version-3.0/amplitude.mdx
@@ -15,9 +15,9 @@ Adapty provides a complete set of data that lets you track [subscription events]
 
 ### How to set up Amplitude integration
 
-Within Adapty, you can set up separate flows for **production** and **test events** from the Apple or Stripe sandbox environment or Google test account.
+Within Adapty, you can set up separate flows for **production** and **test events** from the Apple, Stripe, or Paddle sandbox environment or Google test account.
 
-- For production events, enter the **Production** API keys from the Amplitude dashboard, with a unique API key for each platform: iOS, Android, and Stripe.
+- For production events, enter the **Production** API keys from the Amplitude dashboard, with a unique API key for each platform: iOS, Android, Stripe, and Paddle.
 - For test events, use the **Sandbox** fields as needed.
 
 To set up the Amplitude integration:
@@ -39,9 +39,9 @@ To set up the Amplitude integration:
 
 3. Fill in the integration fields:
 
-    | Field                                      | Description                                                  |
-    | ------------------------------------------ | ------------------------------------------------------------ |
-    | **Amplitude iOS/ Android/ Stripe API key** | Enter the Amplitude **API Key** for iOS/ Android/ Stripe into Adapty. Locate it under **Project settings** in Amplitude. For help, check [Amplitude docs](https://amplitude.com/docs/apis/authentication). Start with **Sandbox** keys for testing, then switch to **Production** keys after successful tests. |
+    | Field                                                | Description                                                  |
+    | ---------------------------------------------------- | ------------------------------------------------------------ |
+    | **Amplitude iOS/ Android/ Stripe/ Paddle API key**   | Enter the Amplitude **API Key** for iOS/ Android/ Stripe/ Paddle into Adapty. Locate it under **Project settings** in Amplitude. For help, check [Amplitude docs](https://amplitude.com/docs/apis/authentication). Start with **Sandbox** keys for testing, then switch to **Production** keys after successful tests. Fill in only the platforms you sell on — a platform without a key sends no events. |
 
     <Zoom>
       <img src="/assets/shared/img/2297782-CleanShot_2023-08-15_at_16.53.512x.webp"

--- a/src/content/docs/version-3.0/firebase-and-google-analytics.mdx
+++ b/src/content/docs/version-3.0/firebase-and-google-analytics.mdx
@@ -39,21 +39,20 @@ Adapty groups users by `subscription_state` (`subscribed`, `active_trial`, `neve
 A Firebase App Instance ID is device-specific. When the same Adapty user opens the app on another device, the new Firebase ID overwrites the previous one. Use a [customer user ID](identifying-users) to maintain user identity across devices.
 :::
 
-### Stripe purchases
+### Web purchases (Stripe and Paddle)
 
-A Stripe purchase reaches Firebase only if the buyer launched your mobile app **first**. The Firebase App Instance ID must be set **before** the Stripe purchase fires.
+A Stripe or Paddle purchase reaches Firebase only if the buyer launched your mobile app **first**. The Firebase App Instance ID must be set **before** the web purchase fires.
 
 For App Store and Play Store purchases, this happens automatically. They originate inside your mobile app, alongside the [`setIntegrationIdentifier`](#configure-your-app-code) call. The Firebase ID is present when the purchase fires.
 
-Stripe purchases originate outside the app, on your server. Your mobile app must call `setIntegrationIdentifier` on launch — before any Stripe purchase fires. Otherwise Adapty has no ID to attach, and the Stripe purchase never reaches Firebase.
+Stripe and Paddle purchases originate outside the app, on the web. Your mobile app must call `setIntegrationIdentifier` on launch — before any web purchase fires. Otherwise Adapty has no ID to attach, and the purchase never reaches Firebase.
 
 ### Limitations
 
 - **Not a Google Ads attribution tool.** This integration sends Adapty events into Firebase and Google Analytics for analytics. It doesn't attribute app installs to Google Ads campaigns (UAC / Universal App Campaigns) or separate paid traffic from organic. For install attribution, use Adapty's built-in [Adapty Attribution](adapty-user-acquisition).
 - **No historical backfill.** Adapty forwards events from the time you enable the integration — past purchases, renewals, and refunds never reach Firebase. (Past data lives in Adapty's [S3](s3-exports) / [GCS](google-cloud-storage) exports, but importing it into Firebase isn't part of this integration.)
-- **Web-only buyers don't reach Firebase.** Adapty forwards purchases to Firebase via the Firebase App Instance ID set by your mobile app. Buyers who never installed the app have no ID — their purchases don't reach Firebase. See [Stripe purchases](#stripe-purchases) above for details, and consider [FunnelFox's Firebase integration](https://funnelfox.com/docs/integrations/subscription-management/adapty) or a Google Analytics web data stream for web tracking.
-- **Paddle purchases aren't included.** This integration doesn't currently support Paddle. Paddle purchases stay in Adapty Analytics and don't reach Firebase via this path.
-- **Stripe purchases inherit Stripe-specific limitations.** See [Stripe integration limitations](stripe#current-limitations).
+- **Web-only buyers don't reach Firebase.** Adapty forwards purchases to Firebase via the Firebase App Instance ID set by your mobile app. Buyers who never installed the app have no ID — their purchases don't reach Firebase. See [Web purchases (Stripe and Paddle)](#web-purchases-stripe-and-paddle) above for details, and consider [FunnelFox's Firebase integration](https://funnelfox.com/docs/integrations/subscription-management/adapty) or a Google Analytics web data stream for web tracking.
+- **Web purchases inherit store-specific limitations.** See [Stripe integration limitations](stripe#current-limitations) and [Paddle integration limitations](paddle#current-limitations).
 
 
 ## Setup instructions
@@ -65,7 +64,7 @@ Stripe purchases originate outside the app, on your server. Your mobile app must
 
     <ZoomImage id="firebase-analytics-integration-settings.webp" width="700px" alt="Adapty Dashboard Firebase integration settings page" />
 
-3. In **Project settings** > **General** > **Your apps**, add an entry for each platform you ship on (iOS / Android / Web). For Stripe, add a Web app entry — there's no native Stripe app type. Each entry generates a unique **Firebase App ID** and a corresponding data stream in Google Analytics. You'll paste the ID into Adapty's Firebase integration settings during the setup.
+3. In **Project settings** > **General** > **Your apps**, add an entry for each platform you ship on (iOS / Android / Web). For Stripe and Paddle, add a Web app entry — there's no native app type for either. Each entry generates a unique **Firebase App ID** and a corresponding data stream in Google Analytics. You'll paste the ID into Adapty's Firebase integration settings during the setup.
 
     <ZoomImage id="firebase-app-id.webp" width="700px" alt="Firebase Console showing the App ID for an iOS app entry" />
 
@@ -75,7 +74,7 @@ Stripe purchases originate outside the app, on your server. Your mobile app must
 
 2. Enable the **Firebase integration** toggle.
 
-3. Enter credentials for each platform you ship on. Adapty needs both a **Firebase App ID** and a **Google Analytics secret** for each platform — each value differs across iOS, Android, and Stripe.
+3. Enter credentials for each platform you ship on. Adapty needs both a **Firebase App ID** and a **Google Analytics secret** for each platform — each value differs across iOS, Android, Stripe, and Paddle. A platform with only one of the two values sends no events.
 
    | Adapty Dashboard | Google Analytics | Where to find it |
    | --- | --- | --- |
@@ -93,7 +92,7 @@ Stripe purchases originate outside the app, on your server. Your mobile app must
 
    <ZoomImage id="revenue-data-options-firebase.webp" width="700px" alt="Firebase integration revenue data row with the four controls" />
 
-5. Map Adapty events to Firebase/Google Analytics event names. Adapty exposes separate event maps for **iOS** and **Android** so you can use different names per platform. **Stripe purchases use the iOS event map** — there's no separate Stripe map.
+5. Map Adapty events to Firebase/Google Analytics event names. Adapty exposes separate event maps for **iOS** and **Android** so you can use different names per platform. **Stripe and Paddle purchases use the iOS event map** — there's no separate map for either.
 
     Google Analytics enforces strict Measurement Protocol limits — 40-character event names, 24-character user-property names, and 36-character values. Google Analytics silently drops custom events that exceed these limits.
 

--- a/src/content/docs/version-3.0/mixpanel.mdx
+++ b/src/content/docs/version-3.0/mixpanel.mdx
@@ -16,7 +16,7 @@ This integration enables you to bring all the Adapty events into Mixpanel. As a 
 ## How to set up Mixpanel integration
 
 1. Open the [Integrations -> Mixpanel](https://app.adapty.io/integrations/mixpanel) page in the Adapty Dashboard.
-2. Enable the toggle and enter your **Mixpanel Token**. You can specify a token for all platforms or limit it to specific platforms if you only want to receive data from certain ones.
+2. Enable the toggle and enter your **Mixpanel Token**. Adapty keeps separate **Production** and **Sandbox** tokens for each platform: iOS, Android, Stripe, and Paddle. Fill in only the platforms you want to receive data from — a platform without a token sends no events.
 3. Set the **Mixpanel Data Residency** to match your Mixpanel project. This field is required and defaults to **US**. Choose **US** for the `api.mixpanel.com` endpoint or **Europe** for `api-eu.mixpanel.com`.
 
 :::warning

--- a/src/content/docs/version-3.0/paddle.mdx
+++ b/src/content/docs/version-3.0/paddle.mdx
@@ -288,9 +288,14 @@ For your Paddle events to work with integrations, your users must be logged into
 Once you integrate with Paddle, Adapty is ready to provide insights right away. To make the most of your Paddle data, you can set up additional Adapty integrations to forward Paddle events—bringing all your subscription analytics into a single Adapty Dashboard.
 
 Integrations you can use to forward and analyze your Paddle events:
+- [Amplitude](amplitude)
 - [AppsFlyer](appsflyer)
-- [Webhook](webhook)
+- [Firebase / Google Analytics](firebase-and-google-analytics)
+- [Mixpanel](mixpanel)
 - [Posthog](posthog)
+- [Webhook](webhook)
+
+Amplitude, Firebase / Google Analytics, and Mixpanel keep separate credentials per platform. Fill in the **Paddle** fields on the integration page — Paddle events don't use your iOS or Android credentials.
 
 ## Current limitations
 


### PR DESCRIPTION
Paddle is becoming a supported store for three realtime integrations: Amplitude, Mixpanel, and Firebase / Google Analytics. Each gets its own optional Paddle credentials in the dashboard, separate from iOS, Android, and Stripe.

**Do not merge until the backend change ships.** Until then, the Firebase article's current statement that Paddle isn't supported is still accurate.

## Changes

- **firebase-and-google-analytics.mdx** — removed the "Paddle purchases aren't included" limitation. Renamed `### Stripe purchases` to `### Web purchases (Stripe and Paddle)`, since the "Firebase App Instance ID must be set before the purchase fires" rule applies identically to Paddle. Added Paddle to the credential-pair step, the Firebase Console Web-app-entry step, and the note that web purchases use the iOS event map (verified: the backend swaps only the app ID and secret for Paddle, leaving the event map alone).
- **amplitude.mdx** — added Paddle to the platform list and the field-table row.
- **mixpanel.mdx** — replaced the vague "token for all platforms or specific platforms" line with the actual per-platform Production/Sandbox breakdown.
- **paddle.mdx** — added Amplitude, Firebase / Google Analytics, and Mixpanel to the list of integrations that forward Paddle events, plus a line clarifying that Paddle needs its own credentials.

## New dashboard fields

| Integration | Fields |
| --- | --- |
| Amplitude | Paddle Production / Sandbox API key |
| Mixpanel | Paddle Production / Sandbox token |
| Firebase / Google Analytics | Firebase app ID for Paddle, Google Analytics secret for Paddle |

## Follow-up

- Screenshots need recapturing once this is on staging: the Amplitude credentials screenshot and `mixpanel.webp` won't show the new Paddle fields.
- Adapty Mail already supports Paddle but is missing from paddle.mdx's forwarding list — pre-existing gap, left out of scope here.

## Checks

`check-mdx-parse` and `lint-mdx` clean. `check-links --diff` reports 0 broken links; the renamed anchor had one reference, updated in the same file.