### PR TITLE
Unity v4 migration guide: document remaining removed and new APIs

### DIFF
--- a/src/content/docs/version-3.0/migration-to-unity-sdk-v4.mdx
+++ b/src/content/docs/version-3.0/migration-to-unity-sdk-v4.mdx
@@ -27,6 +27,9 @@ Adapty Unity SDK 4.0 (beta) introduces flows and renames the paywall APIs accord
 | `PaywallViewDidFailRendering` | `FlowViewDidReceiveError` |
 | `Adapty.SetFallbackPaywalls(...)` (deprecated in v3) | removed — use `Adapty.SetFallback(fileName, ...)` |
 | `Builder.SetIDFACollectionDisabled(...)` (deprecated in v3) | removed — use `Builder.SetAppleIDFACollectionDisabled(...)` |
+| `paywall.Products` (a list of `AdaptyProductReference`) | removed — use `ProductIdentifiers` or `VendorProductIds`, or call `GetPaywallProducts(flow)` for full products |
+| `AdaptyProductReference` | removed as a public type — see [Data model](#data-model) |
+| `paywall.RemoteConfigString` | removed — use `flow.RemoteConfig?.Data` |
 
 `AdaptyPaywallProduct` keeps its name — products still belong to a flow, and `GetPaywallProducts` keeps its name too, now taking an `AdaptyFlow`. The `GetFlow` and `GetFlowForDefaultAudience` methods no longer take a `locale` parameter. The purchase and profile APIs (`MakePurchase`, `RestorePurchases`, `GetProfile`, `Identify`, `UpdateProfile`) and fallbacks via `SetFallback` are unchanged. The onboarding methods still work but are deprecated — see [Onboarding API deprecation](#onboarding-api-deprecation). Some default behaviors changed — see [Default behavior changes](#default-behavior-changes).
 
@@ -97,6 +100,11 @@ The returned type changes from `AdaptyPaywall` to `AdaptyFlow`, and the `locale`
 | _(new)_ | `Paywalls` (list of `AdaptyFlowPaywall`) | Each entry is one paywall variation in the flow, with its own `Name`, `VariationId`, and `ProductIdentifiers`. The web paywall methods take an `AdaptyFlowPaywall` — see [Web paywall methods](#web-paywall-methods). |
 | `ProductIdentifiers`, `VendorProductIds` | kept | On `AdaptyFlow`, these aggregate the products across all paywall variations. Each variation also exposes its own `ProductIdentifiers` and `VendorProductIds`. To fetch products, keep calling `GetPaywallProducts(flow)`. |
 | `HasViewConfiguration` | removed | Remove any `HasViewConfiguration` check from your code — `CreateFlowView` returns an error instead (see [Displaying flows](#displaying-flows)). |
+| `Products` (list of `AdaptyProductReference`) | removed | `AdaptyProductReference` is no longer public, and with it the `PromotionalOfferId`, `WinBackOfferId`, and `AndroidOfferId` values it carried. Use `ProductIdentifiers` — a list of `AdaptyProductIdentifier` with `VendorProductId` and the Android-only `BasePlanId` (v3's `AndroidBasePlanId`) — or call `GetPaywallProducts(flow)` when you need full `AdaptyPaywallProduct` objects with prices and offers. |
+| `RemoteConfigString` | removed | Read the string from the remote config itself: `flow.RemoteConfig?.Data`, or the matching entry in `flow.RemoteConfigs`. |
+| _(new)_ | `FlowVersionId` (nullable) | The version identifier of the flow, or `null` when it isn't available. |
+
+`AdaptyPaywallProduct` gains one field: `FlowProductId`, the product's identifier within the flow, which is `null` for products that don't belong to a flow.
 
 ## Web paywall methods
 
@@ -206,7 +214,7 @@ See [Handle flow & paywall events](unity-handling-events) for the full list of c
 
 - `Adapty.SetObserverModeResolver(...)` with an `IAdaptyUIObserverModeResolver` — drive purchases and restores initiated from flows while the SDK runs in [Observer mode](implement-observer-mode-unity). Previously this was available only in the native iOS and Android SDKs. See [Present flows in Observer mode](unity-present-flows-in-observer-mode).
 - `Adapty.SetSystemRequestsHandler(...)` with an `IAdaptyUISystemRequestsHandler` — reserved for system requests from a flow: OS permission prompts (`FlowViewDidAskPermission`) and app review requests (`FlowViewDidRequestAppReview`). Flows don't trigger these requests yet, so you don't need to register a handler.
-- `AdaptyUICreateFlowViewParameters.Locale` — render a flow or paywall with a specific [Builder localization](add-paywall-locale-in-adapty-paywall-builder) instead of the one Adapty resolves from the device. A flow is localized when its view is created, so this is the only place to choose its localization, and the created view reports the localization it was built with in `view.Locale`. See [Use localizations and locale codes](unity-localizations-and-locale-codes).
+- `AdaptyUICreateFlowViewParameters.Locale` (set it with `SetLocale`) — render a flow or paywall with a specific [Builder localization](add-paywall-locale-in-adapty-paywall-builder) instead of the one Adapty resolves from the device. A flow is localized when its view is created, so this is the only place to choose its localization, and the created view reports the localization it was built with in `view.Locale`. See [Use localizations and locale codes](unity-localizations-and-locale-codes).
 - The new `FlowViewDidReceiveAnalyticEvent` callback on `IAdaptyFlowsEventsListener` is reserved for custom analytic events from a flow. Flows don't emit these to your code yet, so implement it with an empty body.
 - `AdaptyUI.OpenUrl(url, openIn, ...)` and `AdaptyUI.RequestAppReview(...)` — the native handling behind `open_url` actions and app review requests. Call `OpenUrl` from `FlowViewDidPerformAction` to keep the default URL behavior; `RequestAppReview` backs the default app-review prompt, which flows don't trigger yet.
 


### PR DESCRIPTION
A colleague flagged that the Unity v4 migration guide might be missing some renamings. I diffed the SDK's full public API surface between `3.17.0` and the v4 branch tip (`4ed6683`) — every public type, method, field, and enum member — and checked each change against the guide. Three things were uncovered.

## Missing from the guide

**`paywall.Products` / `AdaptyProductReference` removal.** In v3, `AdaptyPaywall.Products` returned a public `IList<AdaptyProductReference>` carrying `VendorProductId`, `PromotionalOfferId`, `WinBackOfferId`, `AndroidBasePlanId`, and `AndroidOfferId`. In v4 the type became `AdaptyFlowPaywall.ProductReference` with every field `internal`, and the list is `internal readonly IList<ProductReference> _Products`. The replacement (`ProductIdentifiers`) only exposes `VendorProductId` and `BasePlanId`, so the promotional / win-back / Android offer IDs are no longer available — called out explicitly.

**`paywall.RemoteConfigString` removal.** Was a `=> RemoteConfig.Data` shortcut; v4 has no equivalent. Use `flow.RemoteConfig?.Data` or the matching entry in `flow.RemoteConfigs`.

**Two new fields.** `AdaptyFlow.FlowVersionId` and `AdaptyPaywallProduct.FlowProductId`, both nullable.

Also named `SetLocale` in the `Locale` bullet — the guide named the field but not its setter.

## Deliberately not documented

`_AdaptyProductId` (public by accident in v3, `internal` now) and `OnPreprocessBuild` / `callbackOrder` (Editor build-validator internals, not app-facing).

## Verification

`check-mdx-parse` and `lint-mdx` pass. Note that a name-based API diff can't catch signature changes where the name survives (for example `GetPaywallProducts(paywall)` → `(flow)`); those were verified by hand in an earlier pass and are already covered by the guide. Enum members are identical between the two versions.