### PR TITLE
Android SDK 4.0.1: locale handling in getFlowConfiguration

### DIFF
--- a/src/content/docs/android/android-get-pb-paywalls.mdx
+++ b/src/content/docs/android/android-get-pb-paywalls.mdx
@@ -135,7 +135,7 @@ AdaptyUI.getFlowConfiguration(flow, loadTimeout = 10.seconds) { result ->
 | Parameter       | Presence       | Description                                                  |
 | :-------------- | :------------- | :----------------------------------------------------------- |
 | **flow**        | required       | An `AdaptyFlow` object obtained via `Adapty.getFlow`. |
-| **locale**      | <p>optional</p><p>default: device locale</p> | The identifier of the [localization](add-paywall-locale-in-adapty-paywall-builder), expected as a language code with one or two subtags separated by `-` (e.g., `en`, `pt-br`). See [Localizations and locale codes](android-localizations-and-locale-codes). |
+| **locale**      | optional | The identifier of the [flow localization](add-paywall-locale-in-adapty-paywall-builder) to render the view with, expected as a language code with one or two subtags separated by `-` (e.g., `en`, `pt-br`). Omit it and the view renders in `en`, or in the flow's default localization when the flow has no `en`. See [Localizations and locale codes](android-localizations-and-locale-codes). |
 | **loadTimeout** | default: 5 sec | This value limits the timeout for this method. If the timeout is reached, cached data or local fallback will be returned. Note that in rare cases this method can timeout slightly later than specified in `loadTimeout`, since the operation may consist of different requests under the hood. |
 
 </TabItem>
@@ -163,7 +163,7 @@ AdaptyUI.getFlowConfiguration(flow, TimeInterval.seconds(10), result -> {
 | Parameter       | Presence       | Description                                                  |
 | :-------------- | :------------- | :----------------------------------------------------------- |
 | **flow**        | required       | An `AdaptyFlow` object obtained via `Adapty.getFlow`. |
-| **locale**      | <p>optional</p><p>default: device locale</p> | The identifier of the [localization](add-paywall-locale-in-adapty-paywall-builder), expected as a language code with one or two subtags separated by `-` (e.g., `en`, `pt-br`). See [Localizations and locale codes](android-localizations-and-locale-codes). |
+| **locale**      | optional | The identifier of the [flow localization](add-paywall-locale-in-adapty-paywall-builder) to render the view with, expected as a language code with one or two subtags separated by `-` (e.g., `en`, `pt-br`). Omit it and the view renders in `en`, or in the flow's default localization when the flow has no `en`. See [Localizations and locale codes](android-localizations-and-locale-codes). |
 | **loadTimeout** | default: 5 sec | This value limits the timeout for this method. If the timeout is reached, cached data or local fallback will be returned. Note that in rare cases this method can timeout slightly later than specified in `loadTimeout`, since the operation may consist of different requests under the hood. |
 
 </TabItem>

--- a/src/content/docs/android/android-localizations-and-locale-codes.mdx
+++ b/src/content/docs/android/android-localizations-and-locale-codes.mdx
@@ -32,7 +32,9 @@ This way `'pt_BR'`, `pt-BR`, and `pt-br` all resolve to the same localization.
 
 In SDK v4, you don't pass a locale code when you fetch a flow — `getFlow` returns the flow with all of its localizations.
 
-- **Flows built in the builder**: the SDK doesn't read the device locale, so resolve it in your app and pass it as the `locale` argument of `AdaptyUI.getFlowConfiguration`. The argument is optional — omit it and the flow renders in its [default locale](add-paywall-locale-in-adapty-paywall-builder#set-the-default-locale).
+- **Flows built in the builder**: the SDK doesn't read the device locale, so resolve it in your app and pass it as the `locale` argument of `AdaptyUI.getFlowConfiguration`. The argument is optional — omit it and the flow renders in `en`, or in its [default locale](add-paywall-locale-in-adapty-paywall-builder#set-the-default-locale) when the flow has no `en` localization. When you request a localization the flow doesn't have, the view falls back to the flow default without an error, and any strings the chosen localization lacks come from the default one.
+
+  Rendering in `en` by default requires Android SDK 4.0.1. In 4.0.0, omitting `locale` renders the flow's default localization.
 - **Custom (remote config) paywalls**: `getFlow` returns every configured localization in `flow.remoteConfigs`. Each entry has a `locale` code and the config content (`jsonString`, or the parsed `dataMap`). Select the entry that matches the user, with your own fallback:
 
 ```kotlin showLineNumbers

--- a/src/content/docs/android/migration-to-android-sdk-v4.mdx
+++ b/src/content/docs/android/migration-to-android-sdk-v4.mdx
@@ -33,7 +33,7 @@ Adapty Android SDK 4.0 introduces flows and renames the paywall APIs accordingly
 
 ## Installation
 
-Set the `adapty-bom` version to `4.0.0` (or later) and sync the project. The BOM resolves the matching `android-sdk` and `android-ui` versions for you. See [Install Adapty SDK](sdk-installation-android) for the dependency declarations.
+Set the `adapty-bom` version to `4.0.1` (or later) and sync the project. The BOM resolves the matching `android-sdk` and `android-ui` versions for you. See [Install Adapty SDK](sdk-installation-android) for the dependency declarations.
 
 ## Removed and deprecated APIs
 
@@ -73,6 +73,8 @@ The fetch return type changes from `AdaptyPaywall` to `AdaptyFlow`, and the conf
       }
   }
 ```
+
+`locale` stays optional on `getFlowConfiguration`: omit it and the view renders in `en`, or in the flow's default localization when the flow has no `en`. See [Localizations and locale codes](android-localizations-and-locale-codes).
 
 ### getPaywallProducts(paywall) → getPaywallProducts(flow)
 


### PR DESCRIPTION
Native Android counterpart to #451, which documented the locale changes for Flutter and RN.

Android SDK [4.0.1](https://github.com/adaptyteam/AdaptySDK-Android/commit/30ef638d3415b267dd40e92551acbff2a0d4b168) (published as `adapty-bom:4.0.1`) changes how `AdaptyUI.getFlowConfiguration` resolves an omitted `locale`: it now prefers the `en` localization and only falls back to the flow's default.

## Changes

- **android-get-pb-paywalls** — the `locale` row in both the Kotlin and Java parameter tables claimed `default: device locale`, which was never true (the SDK doesn't read the device locale). Replaced with the actual behavior.
- **android-localizations-and-locale-codes** — mirrors the Flutter wording: the `en`-first default, the silent fallback when the flow lacks the requested localization, and per-string fallback to the default localization. Adds a version note (the `en` default needs 4.0.1; 4.0.0 renders the flow default).
- **migration-to-android-sdk-v4** — `adapty-bom` pin `4.0.0` → `4.0.1`, plus a line on the `locale` default in the `getFlowConfiguration` section.

## Not mirrored from #451

The Flutter/RN docs also cover reading back the applied localization (`AdaptyUIFlowView.locale` / `view.locale`). On native Android that value is `internal`/`@JvmSynthetic` on `AdaptyUI.FlowConfiguration` — it's exposed only through the crossplatform module for Flutter/RN, so there's nothing for a native Android developer to read.

## Verification

`check-mdx-parse` and `lint-mdx` pass; the link checker reports 0 broken internal links.