### PR TITLE
Document deleting a custom attribute from a profile

### DIFF
--- a/src/content/docs/version-3.0/profiles-crm.mdx
+++ b/src/content/docs/version-3.0/profiles-crm.mdx
@@ -99,6 +99,8 @@ In the **Attributes** section of a profile, you can see custom attributes set vi
 />
 </Zoom>
 
+To change or remove an attribute, click the three dots next to it and select **Edit** or **Delete**. Deleting an attribute affects this profile only — other profiles with the same attribute keep it.
+
 ## Granting a subscription
 
 In a profile, you can extend an active subscription or grant a user lifetime access to an access level — without requiring them to make a purchase.


### PR DESCRIPTION
Adds a sentence to the **Custom attributes** section of `profiles-crm.mdx` covering the three-dots menu (Edit / Delete), and clarifies that deleting an attribute affects only the current profile — other profiles carrying the same attribute keep it.

Preview: [profiles-crm#custom-attributes](https://adapty.io/docs/profiles-crm#custom-attributes)