### PR TITLE
ci: skip src/assets via sparse-checkout in non-build jobs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -27,6 +27,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Exclude src/assets (689 MB — 87% of this repo's checkout payload).
+          # The link checker never reads it. Setting sparse-checkout WITHOUT
+          # `filter` makes actions/checkout add --filter=blob:none to the fetch,
+          # so this cuts transferred bytes, not just working-tree writes.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -46,6 +54,13 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Exclude src/assets (87% of checkout bytes; unused by this job).
+          # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/s3-deploy-development.yml
+++ b/.github/workflows/s3-deploy-development.yml
@@ -9,6 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Exclude src/assets (87% of checkout bytes). lint-mdx.mjs walks all
+          # of src/ but only yields .mdx, so the missing dir is simply not
+          # listed. sparse-checkout without `filter` ⇒ fetch uses blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -121,7 +129,14 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
+      # Only needed for the `git tag` push at the end — the deployed bytes all
+      # come from artifacts, so skip src/assets (87% of checkout bytes).
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/s3-deploy-production.yml
+++ b/.github/workflows/s3-deploy-production.yml
@@ -21,6 +21,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          # Exclude src/assets (87% of checkout bytes; this job only reads
+          # `git log`). sparse-checkout without `filter` ⇒ fetch uses
+          # --filter=blob:none, so it cuts transferred bytes too.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - id: check
         run: |
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
@@ -48,6 +55,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Exclude src/assets (87% of checkout bytes; unused by this job).
+          # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -71,6 +84,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Exclude src/assets (87% of checkout bytes; unused by this job).
+          # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -86,6 +105,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Exclude src/assets (87% of checkout bytes). lint-mdx.mjs walks all
+          # of src/ but only yields .mdx, so the missing dir is simply not
+          # listed. sparse-checkout without `filter` ⇒ fetch uses blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -100,6 +127,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Exclude src/assets (87% of checkout bytes). check-mdx-parse.mjs
+          # scans src/content/docs, src/locales, src/components/reusable only.
+          # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -220,7 +255,14 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
+      # Only needed for the `git tag` push at the end — the deployed bytes all
+      # come from artifacts, so skip src/assets (87% of checkout bytes).
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
 
       - uses: actions/download-artifact@v4
         with:
@@ -345,7 +387,14 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
+      # Only needed for the `git tag` push at the end — the deployed bytes all
+      # come from artifacts, so skip src/assets (87% of checkout bytes).
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -44,6 +44,16 @@ jobs:
           # not just the tip — so a 2-deep clone is insufficient. Manual
           # dispatch may also diff against an arbitrarily old base SHA.
           fetch-depth: 0
+          # Exclude src/assets (689 MB — 87% of this repo's checkout payload).
+          # No step in this job reads it. Setting sparse-checkout WITHOUT
+          # `filter` makes actions/checkout add --filter=blob:none to the fetch,
+          # so this cuts transferred bytes, not just working-tree writes.
+          # Don't add `filter` here: it overrides sparse-checkout, and a full
+          # working tree then lazily re-fetches every blob anyway.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
 
       - name: Get changed translatable files
         id: diff
@@ -70,10 +80,16 @@ jobs:
             BASE="HEAD^1"
           fi
           echo "Diffing $BASE..HEAD"
+          # The trailing pathspecs are redundant with the greps below, but they
+          # keep `--diff-filter=AMR` rename detection from having to inspect
+          # blobs outside these dirs. Under the blobless fetch above that would
+          # mean lazily downloading src/assets blobs just to score similarity.
           CHANGED=$(git diff --name-only --diff-filter=AMR "$BASE" HEAD \
+            -- src/content/docs src/components/reusable src/data/sidebars src/api-reference/specs \
             | grep -E '^(src/content/docs/.+\.mdx|src/components/reusable/.+\.mdx?|src/data/sidebars/.+\.json|src/api-reference/specs/[^./]+\.yaml)$' \
             | tr '\n' ',' | sed 's/,$//')
           DELETED=$(git diff --name-only --diff-filter=D "$BASE" HEAD \
+            -- src/content/docs src/components/reusable src/api-reference/specs \
             | grep -E '^(src/content/docs/.+\.mdx|src/components/reusable/.+\.mdx?|src/api-reference/specs/[^./]+\.yaml)$' \
             | tr '\n' ',' | sed 's/,$//')
           echo "files=$CHANGED" >> $GITHUB_OUTPUT
@@ -103,6 +119,13 @@ jobs:
         locale: ${{ fromJson(needs.setup.outputs.locales) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Exclude src/assets (87% of checkout bytes; unused by this job).
+          # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
 
       - uses: actions/setup-node@v4
         with:
@@ -159,7 +182,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Sparse here is safe for the commit/push below: paths outside the sparse
+      # set keep their SKIP_WORKTREE bit, so `git add`/`git commit` can't drop
+      # src/assets from the tree. This job only stages src/locales/ anyway.
       - uses: actions/checkout@v4
+        with:
+          # Exclude src/assets (87% of checkout bytes; unused by this job).
+          # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
+          sparse-checkout: |
+            /*
+            !/src/assets
+          sparse-checkout-cone-mode: false
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Why

`actions/checkout` intermittently takes 5–34 minutes. Investigated across 692 checkout steps from Jul 27 – Aug 3.

**The intermittency is GitHub-side.** Throughput collapses ~18× during discrete episodes:

| | n | median | implied throughput |
|---|---|---|---|
| baseline | 635 | 18s | **36.7 MB/s** |
| during episodes | 57 | 318s | **2.1 MB/s** |

57 of 692 checkouts (8.2%) exceeded 120s, clustered into **12 episodes** in one week, each lasting minutes to ~40 min and hitting roughly half the checkouts in the window across *all* Azure regions. No GitHub incident was filed for the worst one (Aug 3, worst single checkout **2044s**). Cost: **6.9 h of runner time per week**, and **62% of all time spent in checkout steps is pure stall**.

Ruled out, with data:
- **Our own concurrency** — median is flat (~19s) across every contention bucket; the 2044s outlier happened at *low* concurrency and a 650s stall happened with zero other checkouts in flight.
- **Azure region** — slow checkouts occur in every region; siblings in the same matrix starting the same second differ 17s vs 12min.
- **`fetch-depth: 0`** — shallow checkouts stall too (`apply` 633s, `translate (ja)` 306s).

## What

We can't stop the episodes, so shrink the payload so they stop mattering. Every checkout here moves **~660 MB packed**; `src/assets` is **689 MB of the 787 MB of blobs at HEAD (87%)**, of which **404 MB is 106 animated GIFs**. Per push to `main` that's ~16 GB across ~23 checkouts.

Adding `sparse-checkout` **without** `filter` makes `actions/checkout` add `--filter=blob:none` to the fetch ([source](https://github.com/actions/checkout/blob/v4/src/git-source-provider.ts)), so this cuts *transferred bytes*, not just working-tree writes. Deliberately **not** setting `filter`: it overrides `sparse-checkout`, and a full working tree then lazily re-fetches every blob anyway.

Projected effect on the same episodes:

| checkout size | weekly checkout time | worst single |
|---|---|---|
| 660 MB (today) | 671 min | 34 min |
| ~90 MB (this PR) | **~92 min** | **~4.6 min** |

Applied to the **14 jobs that never read `src/assets`**. The **5 build jobs** (`build-en`, `build-locale-full`, `build-locale-only`, plus the two in `s3-deploy-development`) keep a full checkout — they need the images to build the site.

Also scopes the `setup` job's diff with pathspecs, so `--diff-filter=AMR` rename detection can't lazily fetch `src/assets` blobs just to score similarity under the now-blobless fetch.

## Verified before applying

- No script under `scripts/check-links/`, `lint-mdx.mjs`, or `check-mdx-parse.mjs` references `src/assets`.
- `lint-mdx.mjs` walks all of `src/` but only yields `.mdx`, so the absent directory is simply not listed.
- **Committing under sparse-checkout does not drop excluded paths** — they keep their `SKIP_WORKTREE` bit, so the `apply` job's commit/push to `main` cannot delete `src/assets`. Tested explicitly with `git add -A && git commit`.
- The `/*` + `!/src/assets` non-cone pattern materialises everything except `src/assets`, with no git warning.
- All four workflows still parse; audited every checkout step to confirm the sparse/full split is exactly as intended.

## Note on the trade-off

I used "everything except `src/assets`" rather than an explicit allow-list of needed paths. It captures the dominant 87% win and is robust to scripts later reading new paths; an allow-list would get to ~40 MB but breaks silently whenever a script touches something unlisted.

## Not included

Converting the 106 GIFs to MP4/WebM (404 MB → ~30 MB) would cut every checkout further *with no history rewrite*, since depth-1 ships only HEAD's blobs. Separate piece of work.

## Test

This PR itself exercises the change: the `Check internal links` job in `check-links.yml` runs on `pull_request` with the new sparse checkout.