### PR TITLE
ci: drop fetch-depth 0 from the link-check jobs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -24,9 +24,14 @@ jobs:
       github.event.inputs.check-type == 'all' ||
       github.event.inputs.check-type == 'internal-only'
     steps:
+      # No fetch-depth: 0. The link checker only runs `git diff --name-only
+      # <base>` (base tree vs working tree) and `git show <base>:<path>` — no
+      # merge-base, no log, no history walk — so the base commit and HEAD need
+      # not be connected. Under the blobless fetch that sparse-checkout
+      # enables, fetch-depth: 0 costs ~182 MB of commits and trees across all
+      # 623 branches; the single commit actually needed costs ~0.7 MB.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           # Exclude src/assets (689 MB — 87% of this repo's checkout payload).
           # The link checker never reads it. Setting sparse-checkout WITHOUT
           # `filter` makes actions/checkout add --filter=blob:none to the fetch,
@@ -35,6 +40,24 @@ jobs:
             /*
             !/src/assets
           sparse-checkout-cone-mode: false
+
+      # Fetch just the ref each run below diffs against, at depth 1. Passed via
+      # env rather than interpolated into the script, so a branch name can't be
+      # injected into the shell.
+      - name: Fetch diff base (PR base branch)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --filter=blob:none --depth=1 origin \
+            "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+      - name: Fetch diff base (last production deploy tag)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git fetch --filter=blob:none --depth=1 origin \
+            '+refs/tags/last-production-deploy:refs/tags/last-production-deploy'
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/s3-deploy-production.yml
+++ b/.github/workflows/s3-deploy-production.yml
@@ -52,15 +52,27 @@ jobs:
       group: check-internal-links-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
+      # No fetch-depth: 0 here. The link checker only ever runs
+      # `git diff --name-only <base>` (base tree vs working tree) and
+      # `git show <base>:<path>` — no merge-base, no log, no history walk — so
+      # two disconnected shallow commits are enough. Under the blobless fetch
+      # that sparse-checkout enables, fetch-depth: 0 costs ~182 MB of commits
+      # and trees for all 623 branches; one commit costs ~0.7 MB.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           # Exclude src/assets (87% of checkout bytes; unused by this job).
           # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
           sparse-checkout: |
             /*
             !/src/assets
           sparse-checkout-cone-mode: false
+      # Fetch only the tag being diffed against, at depth 1. `git diff <tag>`
+      # compares that tag's trees to the working tree, so no connecting
+      # history is required.
+      - name: Fetch diff base
+        run: |
+          git fetch --filter=blob:none --depth=1 origin \
+            '+refs/tags/last-production-deploy:refs/tags/last-production-deploy'
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -81,15 +93,21 @@ jobs:
       group: check-localized-links-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
+      # See check-internal-links above: only tree-level diffs against the tag
+      # are needed, so a depth-1 checkout plus a depth-1 tag fetch replaces the
+      # ~182 MB blobless full-history fetch.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           # Exclude src/assets (87% of checkout bytes; unused by this job).
           # sparse-checkout without `filter` ⇒ fetch uses --filter=blob:none.
           sparse-checkout: |
             /*
             !/src/assets
           sparse-checkout-cone-mode: false
+      - name: Fetch diff base
+        run: |
+          git fetch --filter=blob:none --depth=1 origin \
+            '+refs/tags/last-production-deploy:refs/tags/last-production-deploy'
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -43,6 +43,14 @@ jobs:
           # step below covers the whole push range (github.event.before..sha),
           # not just the tip — so a 2-deep clone is insufficient. Manual
           # dispatch may also diff against an arbitrarily old base SHA.
+          #
+          # Unlike the link-check jobs (which were trimmed to depth 1 because
+          # they only ever diff two trees), this job genuinely needs a connected
+          # commit graph: `git merge-base --is-ancestor` below is what
+          # distinguishes a normal push from a force-push, and it cannot answer
+          # that on a shallow clone. Silently losing that guard would make the
+          # diff fall back to HEAD^1 and skip files in multi-commit pushes, so
+          # fetch-depth: 0 stays here on purpose.
           fetch-depth: 0
           # Exclude src/assets (689 MB — 87% of this repo's checkout payload).
           # No step in this job reads it. Setting sparse-checkout WITHOUT


### PR DESCRIPTION
> **Stacked on #457** — based on `ci/sparse-checkout`, since both edit the same `with:` blocks. GitHub will retarget this to `main` automatically when #457 merges. Review #457 first.

## Why

Follow-up to #457. Once those fetches are blobless, the remaining cost of `fetch-depth: 0` is commits and trees — and it turned out to be much larger than I expected when I suggested this:

| blobless fetch | commits | trees | bytes |
|---|---|---|---|
| all branches, full history | 4899 | 22220 | **182.4 MB** |
| main only, full history | 3775 | 16739 | 152.3 MB |
| one commit, no history | 1 | 136 | **0.7 MB** |

My original guess was that the waste was the other 622 branches. It isn't — restricting the refspec to `main` would save only **17%**. Dropping *history* saves **99%**.

And the link checker never needs history. Every git operation it performs:

| call | site | needs |
|---|---|---|
| `git diff --name-only --diff-filter=ACDMR <base>` | `diff.mjs:34` | base trees + working tree |
| `git diff --name-only --diff-filter=DR <base>` | `diff.mjs:48` | base trees + working tree |
| `git show <base>:<path>` | `diff.mjs:76` | one blob (lazy) |
| `git rev-parse --verify <base>` | `diff.mjs:188` | ref present |
| `git diff --name-only --diff-filter=ACMR <base>` | `locales.mjs:110` | base trees + working tree |

No `merge-base`, no `log`, no revision walk — so the base commit and HEAD don't need to be connected at all.

## What

`fetch-depth: 0` → default depth-1 checkout + a depth-1 fetch of only the ref being diffed against, in `check-internal-links`, `check-localized-links` (production deploy) and `internal-links` (PR checks).

**`translate.yml`'s `setup` deliberately keeps `fetch-depth: 0`**, now documented in place. Its `git merge-base --is-ancestor` guard is what separates a normal push from a force-push, and that question can't be answered on a shallow clone. Losing it silently would fall back to `HEAD^1` and skip files in multi-commit pushes — not worth 182 MB.

## Verified end to end against the real remote

Reproduced exactly what `actions/checkout` does — depth-1 blobless fetch, sparse-checkout, checkout, then the targeted tag fetch:

```
blobless depth-1 fetch of main   0.8s
sparse checkout                  5.4s   12167 files, no src/assets
depth-1 tag fetch                1.1s
resulting .git                   29 MB  (vs ~660 MB for a full depth-1 clone)
```

Then the link checker's own commands against that clone:

```
git rev-parse --verify last-production-deploy    -> resolves
git diff --name-only --diff-filter=ACDMR <tag>   -> 19 files, exit 0
git diff --name-only --diff-filter=DR <tag>      -> 0 files
git show <tag>:<path>                            -> returns content
```

Two correctness properties worth calling out, both tested rather than assumed:

- **0 `src/assets` paths are falsely reported as deleted.** Sparse entries keep their `SKIP_WORKTREE` bit, so git treats them as unchanged even though they're absent from the working tree. This matters for #457 too.
- **A path outside the sparse set is still readable on demand.** `git show <tag>:src/assets/…gif` lazily fetched the blob and returned it (`.git` grew 29 → 42 MB). So a script that unexpectedly needs an asset degrades to a slower fetch rather than failing — the failure mode is performance, not breakage.

## Security note

The PR base-branch ref is passed through `env:` rather than interpolated into the shell, so a branch name can't be injected into the `git fetch` command.

## Test

This PR exercises the `pull_request` path of `check-links.yml` — the new depth-1 checkout plus the PR-base-branch fetch — on itself.