### PR TITLE
fix: publish locale builds' hashed assets so locale pages get their CSS

### DIFF
--- a/.github/workflows/s3-deploy-development.yml
+++ b/.github/workflows/s3-deploy-development.yml
@@ -116,6 +116,16 @@ jobs:
           path: build/${{ matrix.locale }}/
           retention-days: 1
 
+      # Astro writes hashed assets to build/_astro/ at the output root, not
+      # inside build/<locale>/, so the locale directory alone is not
+      # self-contained. Without this, locale pages 404 on the CSS chunks unique
+      # to their own build and render unstyled.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.locale }}-assets
+          path: build/_astro/
+          retention-days: 1
+
   deploy:
     needs: [build-en, build-locale]
     runs-on: ubuntu-latest
@@ -177,6 +187,15 @@ jobs:
         with:
           name: build-fr
           path: build/fr/
+
+      # Merge every locale build's hashed assets into the shared _astro/
+      # alongside English's. Filenames are content-hashed, so identical names
+      # carry identical bytes and English assets cannot be clobbered.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: build-*-assets
+          merge-multiple: true
+          path: build/_astro/
 
       - name: Deploy
         uses: reggionick/s3-deploy@v4

--- a/.github/workflows/s3-deploy-production.yml
+++ b/.github/workflows/s3-deploy-production.yml
@@ -260,6 +260,20 @@ jobs:
           path: build/${{ matrix.locale }}/
           retention-days: 1
 
+      # Astro writes hashed assets to the shared build/_astro/ at the output
+      # root, NOT inside build/<locale>/. Uploading only the locale directory
+      # above therefore dropped every CSS chunk unique to this locale's build,
+      # so locale pages referenced /docs/_astro/*.css files that were never
+      # deployed (only build-en's _astro/ reached S3) and rendered unstyled —
+      # callouts lost their box, Tabs lost their tab strip. Asset filenames are
+      # content-hashed, so merging every locale's _astro/ with English's at
+      # deploy time is collision-free by construction.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.locale }}-assets
+          path: build/_astro/
+          retention-days: 1
+
   deploy-full:
     needs: [build-en, build-locale-full]
     runs-on: ubuntu-latest
@@ -321,6 +335,17 @@ jobs:
         with:
           name: build-fr
           path: build/fr/
+
+      # Merge every locale build's hashed assets into the shared _astro/
+      # alongside English's (which arrived with the build-en artifact above).
+      # Content-hashed filenames mean identical names carry identical bytes, so
+      # this cannot clobber English assets. Without this, locale pages 404 on
+      # the CSS chunks unique to their own build.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: build-*-assets
+          merge-multiple: true
+          path: build/_astro/
 
       - name: Deploy
         uses: reggionick/s3-deploy@v4
@@ -392,6 +417,14 @@ jobs:
           path: build/${{ matrix.locale }}/
           retention-days: 1
 
+      # See build-locale-full: Astro emits hashed assets to build/_astro/ at the
+      # output root, so the locale directory alone is not self-contained.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-tr-only-${{ matrix.locale }}-assets
+          path: build/_astro/
+          retention-days: 1
+
   deploy-translations:
     needs: build-locale-only
     runs-on: ubuntu-latest
@@ -448,6 +481,21 @@ jobs:
         with:
           name: build-tr-only-fr
           path: build/fr/
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: build-tr-only-*-assets
+          merge-multiple: true
+          path: build/_astro/
+
+      # Publish the locale builds' hashed CSS/JS chunks. Deliberately WITHOUT
+      # --delete: this job must never prune _astro/, because English's assets
+      # live in the same prefix and are not present in this build. Orphaned
+      # chunks accumulate here and are pruned by the next full deploy, which
+      # syncs the complete build/ with delete-removed.
+      - name: Deploy locale build assets to S3
+        run: |
+          aws s3 sync build/_astro/ s3://${{ secrets.S3_BUCKET }}/_astro/
 
       # Sync locale directories to S3 using AWS CLI —
       # only overwrites zh/, tr/, ru/, es/, ja/, vi/, and fr/ prefixes, leaves English untouched.


### PR DESCRIPTION
## The symptom

On localized pages, callouts lose their box and Tabs lose the tab strip — the labels run together as plain text (`SwiftSwift-Callback`). Reported on `/docs/tr/fetch-paywalls-and-products`.

## It is not a translation bug

That was my first theory and it was wrong. The Turkish MDX does differ structurally from English — it's missing the blank line before `:::important` and before `</TabItem>` after a code fence — but I compiled **both** structures with the same remark plugins (`remark-directive` + `remark-aside`) and they produce **identical** output: `Callout` emitted, `TabItem` emitted, nothing leaked as text. So those blank lines are cosmetic, and "fix the translated files" would have been a hundred-file no-op.

The rendered HTML confirms it — locale and English pages carry byte-identical component markup:

```
class="callout callout-important"   class="callout-icon"   class="itm-tab active"
```

## The actual cause

**Every localized page on the site is missing 2 of its 6 stylesheets.** Verified live across all 7 locales:

```
/docs/fetch-paywalls-and-products          css 3/3 OK
/docs/tr/fetch-paywalls-and-products       css 4/6 OK   <-- BROKEN
/docs/{zh,ru,es,ja,vi,fr}/…                css 4/6 OK   <-- BROKEN
```

The two 404s are exactly the chunks unique to a locale build:

```
/docs/_astro/_slug_.DRLRZimP.css                             404
/docs/_astro/Callout_astro_..._style_index_0_lang.h7_…css     404
```

`astro.config.mjs` sets `outDir: './build'` and leaves `build.assets` at its default, so Astro writes hashed assets to **`build/_astro/` at the output root — not inside `build/<locale>/`**. But the locale build jobs uploaded only:

```yaml
name: build-${{ matrix.locale }}
path: build/${{ matrix.locale }}/     # discards build/_astro/
```

Only `build-en` (`path: build/`) carried an `_astro/` directory, so the deployed `_astro/` has never contained anything but English's assets. Chunks whose content is identical across builds share a hash and resolve — which is why *most* CSS loads and the breakage looked mysterious. The locale route chunk and Callout's scoped styles differ, so they 404.

And because `build: { inlineStylesheets: 'never' }`, there's no inlined fallback — the rules are simply absent. Hence: correct HTML, no styling.

**JS is unaffected** — every script chunk returns 200 and shares hashes with the English build, which is why the pages stayed interactive.

## The fix

Every locale build job now also uploads `build/_astro/`; every deploy job merges those into the shared `_astro/` alongside English's. Filenames are content-hashed, so identical names carry identical bytes — merging cannot clobber English assets.

| job | change |
|---|---|
| `build-locale-full`, `build-locale-only` (prod), `build-locale` (dev) | + upload `build/_astro/` as `…-assets` |
| `deploy-full` (prod), `deploy` (dev) | + merge `build-*-assets` into `build/_astro/` |
| `deploy-translations` (prod) | + merge, + explicit `aws s3 sync build/_astro/ …/_astro/` |

Two deliberate details:

- **The translation-only sync omits `--delete`.** English's assets live in the same `_astro/` prefix and are absent from a translation-only build, so pruning there would delete them. Orphans accumulate and are pruned by the next full deploy, which syncs the complete `build/` with `delete-removed`.
- **Assets sync before the locale HTML sync**, so pages never reference CSS that hasn't been uploaded yet.

## Verification

I could not run a full local build to confirm end-to-end (the locale builds need ~12 GB heap; local builds OOM). What I did verify:

- The 404s are real and reproduce on all 7 locales, on multiple pages each.
- Both 404 filenames are referenced by locale HTML and absent from S3, while English's equivalents resolve.
- Locale HTML requests `/docs/_astro/…`, i.e. the shared root — direct evidence the locale build's own `_astro/` is where those chunks live.
- The locale MDX compiles identically to English, ruling out the content theory.
- Both workflows parse, and I audited the full artifact graph to confirm every locale build publishes assets and every deploy consumes them.

**The real end-to-end proof is the first deploy.** On merge, `deploy-full` syncs the complete `build/` and should retire all 14 of the 404s. Worth re-running the check above on a couple of locales afterwards to confirm — happy to do that.