### PR TITLE
Improve Retention Messaging intro for search

### DIFF
--- a/src/content/docs/version-3.0/retention-messaging-create.mdx
+++ b/src/content/docs/version-3.0/retention-messaging-create.mdx
@@ -2,6 +2,8 @@
 title: "Create a retention message"
 description: "Create default and promo retention messages in Adapty. Write the content, add an offer or plan switch, localize it, and submit it for Apple's review."
 metadataTitle: "Create a retention message | Adapty Docs"
+keywords: ["retention", "apple retention", "retention messaging", "retention messaging api"]
+rank: 80
 ---
 
 Retention messages allow you to reach out to churning subscribers during the cancellation process. When a customer reaches the iOS Cancel Subscription screen, Apple shows them the message that matches their product and locale.

--- a/src/content/docs/version-3.0/retention-messaging-setup.mdx
+++ b/src/content/docs/version-3.0/retention-messaging-setup.mdx
@@ -2,6 +2,8 @@
 title: "Set up Retention Messaging"
 description: "Connect Adapty to Apple's Retention Messaging: configure it in sandbox, pass Apple's performance test, then switch to production."
 metadataTitle: "Set up Retention Messaging | Adapty Docs"
+keywords: ["retention", "apple retention", "retention messaging", "retention messaging api"]
+rank: 80
 ---
 
 Before subscribers can see your retention messages, Apple needs a way to reach Adapty when someone cancels. This article shows how to set up that connection — first in sandbox mode, then in production.
@@ -40,7 +42,7 @@ After you set up the sandbox environment, Adapty allows you to switch the **Sand
 
 <ZoomImage id="retention-messaging-sandbox-mode-toggle.webp" width="700px" alt="The Sandbox mode toggle above the messages table" />
 
-Click **Configure URL**. Adapty registers its endpoint with Apple for production and confirms with "Production URL has been configured." If a different production URL is already set in App Store Connect, click **Replace URL** instead.  
+Click **Configure URL**. Adapty registers its endpoint with Apple for production and confirms with "Production URL has been configured." If a different production URL is already set in App Store Connect, click **Replace URL** instead.
 
 ## Next steps
 

--- a/src/content/docs/version-3.0/retention-messaging.mdx
+++ b/src/content/docs/version-3.0/retention-messaging.mdx
@@ -1,16 +1,18 @@
 ---
 title: "Retention Messaging"
-description: "Show subscribers a custom message inside Apple's Cancel Subscription screen. You create it in Adapty, and Adapty delivers it to Apple automatically."
+description: "Show subscribers a custom message on Apple's Cancel Subscription screen. Create and localize retention messages in Adapty — no backend, no app release."
 metadataTitle: "Apple Retention Messaging | Adapty Docs"
+keywords: ["retention", "apple retention", "retention messaging", "retention messaging api"]
+rank: 80
 ---
 
+[Retention Messaging](https://developer.apple.com/documentation/retentionmessaging) is an Apple feature that shows subscribers a custom message on the iOS **Cancel Subscription** screen, right before they confirm. Use it to cut subscription churn by giving people a reason — or an offer — to stay.
+
+Adapty connects to Apple's Retention Messaging API, so Apple requests the right message in real time whenever a subscriber taps **Cancel Subscription**. Adapty runs that endpoint for you: you write, localize, and test messages in the Adapty Dashboard, and Adapty answers Apple automatically. No backend to build, no app release.
+
+There are two message types. A *default* message is plain copy that applies to everyone on a product. A *promo* message adds a concrete incentive on top: a discount, a free trial, or a switch to a more fitting plan. Apple shows each subscriber the message that matches their product and language.
+
 <CustomDocCardList ids={['retention-messaging-setup', 'retention-messaging-create']} />
-
-Retention Messaging shows subscribers a custom message on the iOS Cancel Subscription screen, before they confirm a cancellation. Use it to persuade churning subscribers to stay.
-
-The *default* message gives every subscriber a reason to stay. A *promo* message adds a concrete incentive: a discount, a free trial, or an opportunity to switch to a more fitting plan. Apple shows each subscriber the message that matches their product and language.
-
-You create, localize, and test messages in the Adapty Dashboard. Adapty delivers them to Apple automatically, with no app release. 
 
 <ZoomImage id="retention-messaging-api.webp" width="700px" alt="Retention Messaging page in the Adapty Dashboard with the messages table and Create Default and Create Message buttons" />
 


### PR DESCRIPTION
Reworks the intro of the [Retention Messaging](src/content/docs/version-3.0/retention-messaging.mdx) overview so it competes for "apple retention messaging" queries.

## What the SERP looks like

Apple, RevenueCat (docs + blog), and Superwall all lead with the same head term and the same hook: Apple calls *your* server in real time when a subscriber cancels, and you have a sub-second budget to answer. RevenueCat sells directly on "no backend work required on your side."

Our page led with a doc card list, used the bare generic term, and buried the equivalent Adapty benefit in the third paragraph.

## Changes

- **Prose before the card list.** The first content after the H1 is now a definitional, snippet-ready sentence instead of a nav widget. Matches the pattern already used in `adapty-ads-manager.mdx` and `api-guides.mdx`.
- **Differentiator promoted to paragraph two** — Apple requests messages in real time, Adapty runs that endpoint, so no backend and no app release.
- **High-intent terms in the opening**: "subscription churn", "Cancel Subscription".
- **`description` reworded** to lead with the feature and end on the differentiator (~152 chars, under SERP truncation).
- Added `keywords` and `rank` to the two child articles.

## Naming

`title` stays **"Retention Messaging"** to match the dashboard. "Retention Messaging API" appears only in the sentence about how Adapty connects — the API is one way to serve messages, not the feature itself, so it shouldn't stand in for the capability in the definition.

"Apple" is kept in `metadataTitle` only, where it disambiguates from email/push retention content in search results without renaming the product.

## Not included

The "700 ms" response budget and "iOS 15.1+" requirement that competitor pages cite. Apple's docs are JS-rendered and I couldn't reach the primary source, so those are secondhand. They'd be strong additions once someone confirms them against Apple's page.

## Verification

`scripts/check-mdx-parse.mjs` and `scripts/lint-mdx.mjs` both pass.