### PR TITLE
RN: require buildReactNativeFromSource on Expo SDK 57+

### DIFF
--- a/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
+++ b/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
@@ -59,7 +59,8 @@ Add the [`expo-build-properties`](https://docs.expo.dev/versions/latest/sdk/buil
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "dynamic"
+            "useFrameworks": "dynamic",
+            "buildReactNativeFromSource": true
           }
         }
       ]
@@ -67,6 +68,8 @@ Add the [`expo-build-properties`](https://docs.expo.dev/versions/latest/sdk/buil
   }
 }
 ```
+
+`buildReactNativeFromSource` is required on **Expo SDK 57 and later**. Expo SDK 57 ships a prebuilt React Native framework whose headers other packages can't reach once frameworks are dynamic, so the iOS build fails with errors like `'React/RCTBridge.h' file not found` in `expo-updates` or `@expo/ui`. Building React Native from source avoids the conflict, at the cost of longer iOS builds. On Expo SDK 56 and earlier, you can omit this option.
 
 Then install the plugin and regenerate the native project:
 

--- a/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
@@ -114,7 +114,8 @@ v4 pulls the native iOS SDKs (`Adapty`, `AdaptyUI`, `AdaptyPlugin`) through Swif
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "dynamic"
+            "useFrameworks": "dynamic",
+            "buildReactNativeFromSource": true
           }
         }
       ]
@@ -122,6 +123,8 @@ v4 pulls the native iOS SDKs (`Adapty`, `AdaptyUI`, `AdaptyPlugin`) through Swif
   }
 }
 ```
+
+`buildReactNativeFromSource` is required on **Expo SDK 57 and later**. Expo SDK 57 ships a prebuilt React Native framework whose headers other packages can't reach once frameworks are dynamic, so the iOS build fails with errors like `'React/RCTBridge.h' file not found` in `expo-updates` or `@expo/ui`. Building React Native from source avoids the conflict, at the cost of longer iOS builds. On Expo SDK 56 and earlier, you can omit this option.
 
 Then install the plugin and regenerate the native project:
 


### PR DESCRIPTION
Reported on the React Native SDK: on **Expo SDK 57 and later**, `"buildReactNativeFromSource": true` must be set alongside `useFrameworks: "dynamic"`, or the iOS build conflicts with other packages. Confirmed by Stanislav.

Expo SDK 57 ships a prebuilt React Native framework whose headers other pods can't reach once frameworks are dynamic, so the build fails with `'React/RCTBridge.h' file not found` in `expo-updates` or `@expo/ui`. Building React Native from source avoids the conflict, at the cost of longer iOS builds.

## Changes

Same edit in the two places the `expo-build-properties` config appears:

- `sdk-installation-react-native-expo.mdx` — "Adapty SDK 4.0: enable Swift Package Manager"
- `migration-to-react-native-sdk-v4.mdx` — "iOS: native SDKs now come through Swift Package Manager" → Expo

Added the key to the JSON snippet plus one paragraph explaining the cause, the build-time cost, and that Expo 56 and earlier can omit it.

## Notes for review

- **Placed in the setup step, not Troubleshooting.** It's required for 57+, so it belongs in the config a reader copies rather than in a section they only reach after a failed build. Can add a parallel Troubleshooting entry keyed on the error message if that's preferable.
- **Kept one snippet instead of a separate 57+-only block.** The version condition is carried by the sentence below it. Tradeoff: a reader on Expo 56 who copies verbatim gets slower builds; the last sentence covers that.
- **Pure React Native guide untouched** — `expo-build-properties` doesn't apply there and the conflict is specific to Expo's prebuilt RN.
- **Open question for the SDK team:** if the Adapty Expo config plugin could set this automatically (like `replaceAndroidBackupConfig`), this text should shrink to a one-liner.

Ref: https://github.com/adaptyteam/AdaptySDK-React-Native/issues/332

`check-mdx-parse` and `lint-mdx` pass.