### PR TITLE
Document granting an initial virtual currency balance

### DIFF
--- a/src/api-reference/specs/adapty-api.yaml
+++ b/src/api-reference/specs/adapty-api.yaml
@@ -1318,6 +1318,8 @@ paths:
             format: uuid
           description: |
             A UUID v4 that makes the request idempotent. If you retry a request with the same key, Adapty returns the result of the original transaction without changing balances again. Must be a valid UUID v4.
+
+            Keys are remembered for up to an hour, scoped to a single profile. After that window, a request with the same key is applied as a new transaction — so use the key to retry a call safely, not to deduplicate a grant over the long term.
       requestBody:
         required: true
         content:

--- a/src/content/docs/version-3.0/create-virtual-currency.mdx
+++ b/src/content/docs/version-3.0/create-virtual-currency.mdx
@@ -33,7 +33,7 @@ To create a virtual currency:
 You can't change the currency's **Code** after you create it. You can still edit the **Name** after the fact.
 :::
 
-When you introduce a new currency, the starting balance for every user profile is 0.
+When you introduce a new currency, the starting balance for every user profile is 0. To hand users a balance before they buy anything, see [Grant an initial balance](grant-initial-balance).
 
 <ZoomImage id="new-currency-step-1.webp" width="500px" alt="The General step of the New virtual currency drawer, with Code, Name, and Description fields" />
 

--- a/src/content/docs/version-3.0/grant-initial-balance.mdx
+++ b/src/content/docs/version-3.0/grant-initial-balance.mdx
@@ -1,0 +1,77 @@
+---
+title: "Grant an initial balance"
+description: "Give new users a starting virtual currency balance through the server-side API, and backfill existing users when you launch a new currency."
+metadataTitle: "Grant an initial balance | Adapty Docs"
+---
+
+:::link
+Main article: [Virtual currencies](virtual-currencies)
+:::
+
+Every profile starts with a balance of 0 in every currency, and [linked products](create-virtual-currency#link-products) only grant credits on a purchase or a renewal. So a user who has not bought anything never receives credits automatically.
+
+You can still give new users a starting balance: a welcome bonus, a free trial allowance, or a set of lives. Grant it from your backend through the [server-side API](getting-started-with-server-side-api), after you identify the user.
+
+## Grant the balance for a new user
+
+1. **Identify the user first**: A balance belongs to one profile and never moves to another one, so grant the credits only after the profile has a customer user ID. Identify the user in your app through the SDK (see [Identify users](ios-quickstart-identify)) or from your backend through the server-side API.
+
+    Granting to an anonymous profile is the most common mistake here. Anonymous profiles are tied to one app installation, so the user loses the credits when they reinstall your app or open it on another device. See [Balances, profiles, and devices](virtual-currency-balance#balances-profiles-and-devices) for the full picture.
+
+2. **Grant the credits**: Call [Create virtual currency transaction](api-adapty/operations/createVirtualCurrencyTransaction) with a positive `amount`. This example grants 500 tokens:
+
+    ```bash title="Grant an initial balance"
+    curl -X POST https://api.adapty.io/api/v2/server-side-api/vc/transactions/ \
+      -H "Authorization: Api-Key {your secret key}" \
+      -H "adapty-customer-user-id: user-42" \
+      -H "Idempotency-Key: 6f2c0b34-9c3a-4f5e-8a1d-2b7e5c9d0a11" \
+      -H "Content-Type: application/json" \
+      -d '{
+            "items": [{"currency_code": "TOKENS", "amount": 500}],
+            "metadata": {"reason": "initial_balance"}
+          }'
+    ```
+
+    The response returns the new balance:
+
+    ```json title="Response"
+    {
+      "transaction_id": "3a9f8e21-5d4c-4b7a-9e01-8c6d2f4b1a37",
+      "balances": [
+        { "code": "TOKENS", "name": "Tokens", "balance": 500, "held": 0, "available": 500 }
+      ]
+    }
+    ```
+
+    Credits granted this way never expire, unlike the per-cycle credits of a linked subscription.
+
+    The `metadata` field is optional. A tag such as `reason: initial_balance` makes the grant easy to recognize in the [transaction history](api-adapty/operations/listVirtualCurrencyTransactions), and to separate from purchase credits in your own reporting.
+
+3. **Record the grant in your database**: Store the fact that this user received their initial balance, so a repeated sign-in or a retried job doesn't grant it twice. The next section explains why this record is necessary.
+
+## Grant it exactly once
+
+Your own database is the source of truth for whether a user has received their initial balance. Two approaches that look sufficient are not:
+
+- **`Idempotency-Key` protects one call, not one user**: Retrying a request with the same key returns the original result instead of granting again, so a single call is safe to retry after a timeout. Adapty remembers each key for up to an hour, per profile. After that, the same key grants again, so the header can't tell you months later whether a user already got their initial balance. Generate a fresh key for each new grant.
+- **Reading the balance first proves nothing**: A balance of 0 means either that the user was never granted credits, or that they were granted and spent them all. [List virtual currency balances](api-adapty/operations/listVirtualCurrencyBalances) can't tell the two apart.
+
+So check your own record before you call the API, and write the record after a successful response.
+
+## Backfill existing users
+
+When you create a currency, every existing profile starts at 0, and [product links only apply going forward](create-virtual-currency#link-products). To give your current users a starting balance, run a one-off backfill from your backend.
+
+1. In your own database, collect the customer user IDs to grant to.
+2. For each one, call [Create virtual currency transaction](api-adapty/operations/createVirtualCurrencyTransaction) as shown above. There is no bulk endpoint: one request grants to one profile, and a single request can cover up to 20 currencies for that profile.
+3. Keep the per-user record from the previous section as you go, so you can stop the job and resume it without granting twice.
+4. Stay under the rate limit of 600 requests per minute per app. A request over the limit fails with `rate_limited`, so throttle the job and retry the failed users.
+
+:::tip
+Backfill only the users you want to reach, such as active or paying ones. Credits granted through the API never expire, so a balance you hand out now stays on the profile until the user spends it.
+:::
+
+## Next steps
+
+- Spend the balance and read it at runtime: [Virtual currency quickstart](virtual-currency-quickstart).
+- Check what a user holds and audit every change: [Virtual currency balance](virtual-currency-balance).

--- a/src/content/docs/version-3.0/virtual-currencies.mdx
+++ b/src/content/docs/version-3.0/virtual-currencies.mdx
@@ -5,7 +5,7 @@ metadataTitle: "Virtual currencies | Adapty Docs"
 keywords: ['virtual currency', 'virtual currencies', 'in-app currency']
 ---
 
-<CustomDocCardList ids={['virtual-currency-quickstart', 'create-virtual-currency', 'virtual-currency-balance']} />
+<CustomDocCardList ids={['virtual-currency-quickstart', 'create-virtual-currency', 'grant-initial-balance', 'virtual-currency-balance']} />
 
 Grant your users virtual currency — AI tokens, credits, or coins — when they buy products or renew subscriptions. Define a currency once, link it to the products that should award it, and Adapty credits each user automatically and keeps their balance. Your app reads and spends that balance through the [server-side API](getting-started-with-server-side-api) — for example, to charge tokens per generation.
 
@@ -16,7 +16,7 @@ Grant your users virtual currency — AI tokens, credits, or coins — when they
 1. [Create a virtual currency](create-virtual-currency): Open **Products** and click the **Virtual currency** tab. Click **New virtual currency**. Define a currency with a code, a name, and an optional description.
 2. **Link the currency to products**: Map the currency to one-time or subscription products and set how many credits each purchase grants.
 3. **Credits are granted automatically**: When a user buys a linked one-time product or renews a linked subscription, Adapty adds the configured credits to their balance.
-4. **Read and spend the balance**: Your app reads each user's balance and grants or spends credits through the server-side API.
+4. **Read and spend the balance**: Your app reads each user's balance and grants or spends credits through the server-side API. Use the same API to [grant an initial balance](grant-initial-balance) to users who have not bought anything yet.
 5. **Track every change**: Each balance change is listed on the [user's profile](virtual-currency-balance).
 
 For a complete walkthrough — from currency setup to spending credits through the API — follow the [Virtual currency quickstart](virtual-currency-quickstart).

--- a/src/content/docs/version-3.0/virtual-currency-quickstart.mdx
+++ b/src/content/docs/version-3.0/virtual-currency-quickstart.mdx
@@ -42,5 +42,5 @@ This quickstart sets up a token currency end to end: a subscription grants users
    ```
 
    The transaction is atomic and returns the updated balance. If the user can't cover the cost, the request returns `insufficient_balance` and nothing changes. Include an `Idempotency-Key` header to safely retry requests.
-4. To run a win-back promo, grant tokens through the same endpoint with a positive `amount`. Credits you grant this way never expire.
+4. To run a win-back promo, grant tokens through the same endpoint with a positive `amount`. Credits you grant this way never expire. To give users a balance before their first purchase, see [Grant an initial balance](grant-initial-balance).
 5. Review every change in the user's [profile](virtual-currency-balance) or in the [transaction history](api-adapty/operations/listVirtualCurrencyTransactions), so you can audit the economy at any time.

--- a/src/data/sidebars/tutorial.json
+++ b/src/data/sidebars/tutorial.json
@@ -544,6 +544,11 @@
           },
           {
             "type": "doc",
+            "id": "grant-initial-balance",
+            "label": "Grant an initial balance"
+          },
+          {
+            "type": "doc",
             "id": "virtual-currency-balance",
             "label": "Virtual currency balance"
           }


### PR DESCRIPTION
## What

Adds a **Grant an initial balance** article to the Virtual currencies category, plus a fix to the `Idempotency-Key` description in the API spec.

Every profile starts at 0, and linked products only grant credits on a purchase or renewal — so nothing in the docs answered "how do I give free users a starting balance?". This is a recurring question for AI apps (welcome credits) and games (starting coins).

## The article

`grant-initial-balance.mdx` covers:

- **Grant the balance for a new user** — identify first, then `createVirtualCurrencyTransaction` with a positive `amount`, then record the grant. Identification leads because granting to an anonymous profile silently loses the credits on reinstall or on a second device.
- **Grant it exactly once** — the two shortcuts that look sufficient and are not: `Idempotency-Key` protects one call rather than one user, and reading the balance first can't distinguish "never granted" from "granted and spent".
- **Backfill existing users** — new currencies leave every existing profile at 0, and product links only apply going forward. One request per profile (no bulk endpoint), throttled under 600 req/min, resumable via the per-user record.

## Spec change

`adapty-api.yaml` documented the `Idempotency-Key` retry semantics with no retention window, which reads as though the key were a durable per-user lock. It's a KeyDB cache with `TTL_SECONDS = 3600` scoped per profile (`virtual_currency_idempotency_key_cache.py` in `adapty-dashboard-api`), so the window is now stated. This is why the article tells readers to keep their own record instead of deriving a deterministic key per user.

## Accuracy notes

Facts traced to `adapty-api.yaml` or the backend: 20-currency cap per request, 600 req/min per app, non-expiring API-granted credits, `metadata` constraints, and the response shape including the required `name` field.

`Retry-After` is documented only on the 409 `idempotency_in_flight`, **not** on the 429 `rate_limited` — an earlier draft attributed it to rate limiting; corrected.

## Cross-links

Entry points added at `create-virtual-currency.mdx` (the "starting balance is 0" line), the `virtual-currencies.mdx` doc card list and "How it works" step 4, and quickstart step 4. Sidebar entry in `tutorial.json` after **Create virtual currency**.

## Verification

- `check-mdx-parse` — clean
- `lint-mdx` — clean
- `check-links-diff` — 33 links, 0 broken, 0 stale (includes API-reference operation links and both deep anchors)
- `adapty-api.yaml` re-parses; rendered description verified

No screenshots needed — the article is backend/API only.