### PR TITLE
Reorder header language dropdown

### DIFF
--- a/src/data/locales.ts
+++ b/src/data/locales.ts
@@ -1,6 +1,7 @@
-export const SUPPORTED_LOCALES = ['zh', 'tr', 'ru', 'es', 'ja', 'vi', 'fr'] as const;
+// Order here drives the order of the language dropdown in the header.
+export const SUPPORTED_LOCALES = ['zh', 'tr', 'ru', 'fr', 'vi', 'es', 'ja'] as const;
 export type Locale = typeof SUPPORTED_LOCALES[number];
-export const LOCALE_NAMES: Record<Locale, string> = { zh: '中文', tr: 'Türkçe', ru: 'Русский', es: 'Español', ja: '日本語', vi: 'Tiếng Việt', fr: 'Français' };
+export const LOCALE_NAMES: Record<Locale, string> = { zh: '中文', tr: 'Türkçe', ru: 'Русский', fr: 'Français', vi: 'Tiếng Việt', es: 'Español', ja: '日本語' };
 
 /**
  * Returns the subset of SUPPORTED_LOCALES to build in this run.


### PR DESCRIPTION
Changes the order of languages in the header language switcher to:

English → 中文 → Türkçe → Русский → Français → Tiếng Việt → Español → 日本語

## Implementation

The dropdown (both desktop and mobile) is rendered from `SUPPORTED_LOCALES` in `src/data/locales.ts`, with English hardcoded first, so reordering that array is the whole change. `LOCALE_NAMES` was reordered to match for readability.

Every other consumer of `SUPPORTED_LOCALES` treats it as a set (membership checks) or a list where order is purely cosmetic (sitemap entries, hreflang tags), so nothing else is affected. The CI locale build matrices are separate literals and were left alone.

## Verification

Checked against a local dev server: both the desktop and mobile menus render in the requested order, and the hrefs still point at the right locale (`/docs/zh/`, `/docs/tr/`, …) on both English and localized pages.