### PR TITLE
Document Ads Manager commands in the Developer CLI

### DIFF
--- a/src/components/reusable/AdsManagerSkill.mdx
+++ b/src/components/reusable/AdsManagerSkill.mdx
@@ -8,6 +8,8 @@ The [ads-manager skill](https://github.com/adaptyteam/adapty-sdk-integration-ski
 
 The skill drives the Adapty CLI, so install and authenticate the CLI first — see the [quickstart guide](developer-cli-quickstart).
 
+In a corporate Cowork workspace, an administrator must add `*.adapty.io` to the domain allowlist. Until they do, the skill cannot reach Adapty.
+
 To install, pick the form for your tool. The full list is in the [skill README](https://github.com/adaptyteam/adapty-sdk-integration-skill).
 
 **Claude Code**

--- a/src/components/reusable/AdsManagerSkill.mdx
+++ b/src/components/reusable/AdsManagerSkill.mdx
@@ -1,0 +1,48 @@
+---
+no_index: true
+---
+
+The [ads-manager skill](https://github.com/adaptyteam/adapty-sdk-integration-skill) teaches your AI coding tool to operate Apple Ads through the `adapty asa` commands. It knows the order commands compose in, what to read before writing anything, and which calls spend money.
+
+**Supported tools**: Claude Code, GitHub Copilot CLI, OpenAI Codex, Gemini CLI.
+
+The skill drives the Adapty CLI, so install and authenticate the CLI first — see the [quickstart guide](developer-cli-quickstart).
+
+To install, pick the form for your tool. The full list is in the [skill README](https://github.com/adaptyteam/adapty-sdk-integration-skill).
+
+**Claude Code**
+
+```bash
+claude plugin marketplace add adaptyteam/adapty-sdk-integration-skill
+claude plugin install adapty-sdk-integration@adapty
+```
+
+This plugin also contains the SDK integration skill. Both are installed together.
+
+**GitHub Copilot CLI**
+
+```bash
+gh skill install adaptyteam/adapty-sdk-integration-skill
+```
+
+**Gemini CLI**
+
+```bash
+gemini skills install https://github.com/adaptyteam/adapty-sdk-integration-skill
+```
+
+**OpenAI Codex or any other tool** — use the [skills CLI](https://skills.sh) (note that skills installed this way don't update automatically):
+
+```bash
+npx skills add adaptyteam/adapty-sdk-integration-skill
+```
+
+Alternatively, clone the repo and copy `skills/ads-manager/` into your tool's skills directory.
+
+After installing, run the skill in your project:
+
+```bash
+/ads-manager
+```
+
+Reading metrics and dry runs cost nothing. Every other command reaches Apple within seconds, spends real money, and cannot be undone — the skill asks before each one, and so should you.

--- a/src/content/docs/developer-cli/developer-cli-ads-manager-reference.mdx
+++ b/src/content/docs/developer-cli/developer-cli-ads-manager-reference.mdx
@@ -1,0 +1,631 @@
+---
+title: "Ads Manager commands for the Adapty Developer CLI"
+description: "Reference for every adapty asa command — campaigns, ad groups, keywords, ads, automations, and metrics."
+metadataTitle: "Ads Manager CLI Commands | Adapty Docs"
+---
+
+This article lists every [Ads Manager](adapty-ads-manager) command in the Adapty CLI, with its arguments, flags, and accepted values. Ads Manager commands live under the `adapty asa` topic.
+
+:::link
+For prerequisites, safe write practices, and task-based examples, see [Manage Ads Manager from the CLI](developer-cli-ads-manager).
+:::
+
+These commands need a connected Apple Ads account and an active Ads Manager subscription. Run [`adapty asa whoami`](#adapty-asa-whoami) to check both. For the rest of the CLI, see the [command reference](developer-cli-reference).
+
+## Global flags \{#global-flags\}
+
+These flags are available on all Ads Manager commands.
+
+| Flag | Description |
+|---|---|
+| `--json` | Output as JSON instead of formatted text |
+| `--help` | Show command help |
+
+All `list` commands also accept pagination flags:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--page` | `1` | Page number |
+| `--page-size` | `20` | Items per page (max: 100) |
+
+All commands that change your account accept these flags:
+
+| Flag | Description |
+|---|---|
+| `--yes`, `-y` | Apply without asking for confirmation. Required when the output is piped or `--json` is used |
+| `--idempotency-key` | Fixed key for this write. A repeat with the same key and body within 24 hours returns the stored result instead of applying the change again |
+
+Ads Manager commands take no `--app` flag. The scope is the company that your token belongs to. `--app` exists on some `list` commands as a filter only.
+
+## List filters \{#list-filters\}
+
+Filters narrow the query itself, not the printed page. An unfiltered `keywords list` pages through every keyword in the account, so scope each read to the level you need.
+
+| Filter | Accepted by |
+|---|---|
+| `--campaign-group` | All lists in this table |
+| `--app` | `campaigns`, `ad-groups`, `keywords`, `negative-keywords`, `search-terms`, `product-pages`, `creatives` |
+| `--campaign` | `ad-groups`, `keywords`, `negative-keywords`, `search-terms`, `ads` |
+| `--ad-group` | `keywords`, `negative-keywords`, `search-terms`, `ads` |
+| `--status` | `campaigns`, `ad-groups`, `ads` (`ENABLED` or `PAUSED`), `keywords` (`ACTIVE` or `PAUSED`) |
+| `--search` | All lists except `product-pages` and `creatives`. Case-insensitive substring match on the name |
+
+`--campaign-group`, `--app`, `--campaign`, and `--ad-group` take the UUIDs printed by the matching `list` command, and each one is repeatable:
+
+```bash
+adapty asa keywords list --ad-group <ad-group-id> --ad-group <other-ad-group-id>
+```
+
+An ID that belongs to another company matches nothing, so the page comes back empty instead of returning an error.
+
+## Account \{#account\}
+
+### adapty asa whoami
+
+Show the company, how Ads Manager access was granted, and whether Apple Ads is connected.
+
+```bash
+adapty asa whoami
+```
+
+Run this command first. It reports whether the two prerequisites for every other command are met.
+
+### adapty asa connect
+
+Link an Apple Ads account to Adapty.
+
+```bash
+adapty asa connect
+```
+
+The command prints an Apple authorization link and waits until Apple reports the account as connected.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--wait` / `--no-wait` | `--wait` | Wait until Apple Ads reports as connected. `--no-wait` returns immediately |
+| `--timeout` | `300` | Seconds to wait for the browser step |
+
+### adapty asa orgs list
+
+List the campaign groups (Apple Ads organizations) available to your company.
+
+```bash
+adapty asa orgs list
+```
+
+The ID returned here is the `--org` value for [`campaigns create`](#adapty-asa-campaigns-create).
+
+Accepts [pagination flags](#global-flags).
+
+### adapty asa apps list
+
+List the apps promoted in Apple Ads.
+
+```bash
+adapty asa apps list
+```
+
+Accepts [pagination flags](#global-flags).
+
+## Campaigns \{#campaigns\}
+
+### adapty asa campaigns list
+
+List [campaigns](ads-manager-create-campaign). Returns metadata only — read performance numbers with [`asa metrics`](#adapty-asa-metrics).
+
+```bash
+adapty asa campaigns list --app <app-id> --status PAUSED
+```
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group`, `--app`, `--search`, and `--status` [list filters](#list-filters).
+
+### adapty asa campaigns get
+
+Get details for a specific campaign.
+
+```bash
+adapty asa campaigns get <campaign-id>
+```
+
+| Argument | Description |
+|---|---|
+| `campaign-id` | Campaign ID (UUID) |
+
+### adapty asa campaigns create
+
+Create a campaign.
+
+```bash
+adapty asa campaigns create --org <campaign-group-id> --name "Winter push" --adam-id 123456 --country US --daily-budget 50
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--org` | Yes | Campaign group ID (UUID). See [`orgs list`](#adapty-asa-orgs-list) |
+| `--name` | Yes | Campaign name |
+| `--adam-id` | Yes | App Store app ID (`adam_id`) |
+| `--country` | Yes | Country or region code. Repeat for several: `--country US --country CA` |
+| `--daily-budget` | Yes | Daily budget as a plain amount, for example `50` or `12.50` |
+| `--budget` | No | Lifetime budget |
+| `--target-cpa` | No | Target cost per acquisition |
+| `--currency` | No | Currency code for the amounts in this call. Default: `USD` |
+| `--bidding-strategy` | No | `MANUAL_CPT` or `MAX_CONVERSIONS`. Apple defaults to `MANUAL_CPT` |
+| `--ad-channel-type` | No | `SEARCH` or `DISPLAY`. Default: `SEARCH` |
+| `--billing-event` | No | `TAPS` or `IMPRESSIONS`. Default: `TAPS` |
+| `--supply-source` | No | Supply source, repeatable. Default: `APPSTORE_SEARCH_RESULTS` |
+| `--status` | No | Initial status: `ENABLED` or `PAUSED` |
+
+### adapty asa campaigns update
+
+Update an existing campaign.
+
+```bash
+adapty asa campaigns update <campaign-id> --daily-budget 80 --status PAUSED
+```
+
+| Argument | Description |
+|---|---|
+| `campaign-id` | Campaign ID (UUID) |
+
+| Flag | Description |
+|---|---|
+| `--name` | New campaign name |
+| `--status` | `ENABLED` or `PAUSED` |
+| `--country` | Replaces the country list. Repeat for several |
+| `--daily-budget` | New daily budget |
+| `--budget` | New lifetime budget |
+| `--target-cpa` | New target cost per acquisition |
+| `--bidding-strategy` | `MANUAL_CPT` or `MAX_CONVERSIONS` |
+| `--currency` | Currency code for the amounts in this call. Default: `USD` |
+
+At least one flag is required.
+
+## Ad groups \{#ad-groups\}
+
+### adapty asa ad-groups list
+
+List [ad groups](ads-manager-create-ad-group). Returns metadata only — read performance numbers with [`asa metrics`](#adapty-asa-metrics).
+
+```bash
+adapty asa ad-groups list --campaign <campaign-id>
+```
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group`, `--app`, `--campaign`, `--search`, and `--status` [list filters](#list-filters).
+
+### adapty asa ad-groups get
+
+Get details for a specific ad group.
+
+```bash
+adapty asa ad-groups get <ad-group-id>
+```
+
+| Argument | Description |
+|---|---|
+| `ad-group-id` | Ad group ID (UUID) |
+
+### adapty asa ad-groups create
+
+Create an ad group in a campaign.
+
+```bash
+adapty asa ad-groups create --campaign <campaign-id> --name "Brand terms" --default-bid 1.20
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--campaign` | Yes | Campaign ID (UUID) |
+| `--name` | Yes | Ad group name |
+| `--default-bid` | Yes | Default bid as a plain amount, for example `1.20` |
+| `--cpa-goal` | No | Cost per acquisition goal |
+| `--pricing-model` | No | `CPC` or `CPM`. Apple requires one on every ad group. Default: `CPC` |
+| `--start-time` | No | Schedule start (`YYYY-MM-DD`). Defaults to today |
+| `--end-time` | No | Schedule end (`YYYY-MM-DD`) |
+| `--automated-keywords` / `--no-automated-keywords` | No | Let Apple add keywords automatically |
+| `--currency` | No | Currency code for the amounts in this call. Default: `USD` |
+| `--status` | No | Initial status: `ENABLED` or `PAUSED` |
+
+### adapty asa ad-groups update
+
+Update an existing ad group.
+
+```bash
+adapty asa ad-groups update <ad-group-id> --default-bid 1.50 --status PAUSED
+```
+
+| Argument | Description |
+|---|---|
+| `ad-group-id` | Ad group ID (UUID) |
+
+| Flag | Description |
+|---|---|
+| `--name` | New ad group name |
+| `--status` | `ENABLED` or `PAUSED` |
+| `--default-bid` | New default bid |
+| `--cpa-goal` | New cost per acquisition goal |
+| `--start-time` | Schedule start (`YYYY-MM-DD`) |
+| `--end-time` | Schedule end (`YYYY-MM-DD`) |
+| `--automated-keywords` / `--no-automated-keywords` | Let Apple add keywords automatically |
+| `--currency` | Currency code for the amounts in this call. Default: `USD` |
+
+At least one flag is required. The parent campaign is resolved on the server and is never passed.
+
+## Keywords \{#keywords\}
+
+Keyword commands are applied as a batch of at most 100 items per call. See [Manage keywords](ads-manager-manage-keywords) for the dashboard equivalent.
+
+### adapty asa keywords list
+
+List targeting keywords. Returns metadata only — read performance numbers with [`asa metrics`](#adapty-asa-metrics).
+
+```bash
+adapty asa keywords list --ad-group <ad-group-id> --status ACTIVE
+```
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group`, `--app`, `--campaign`, `--ad-group`, `--search`, and `--status` [list filters](#list-filters). Filter by `--ad-group` — without a filter, this is the widest read in the topic.
+
+### adapty asa keywords add
+
+Add targeting keywords to an ad group.
+
+```bash
+adapty asa keywords add --ad-group <ad-group-id> --text "running shoes" --text "trail shoes" --bid 1.20
+```
+
+Read the keywords from a file instead, one per line:
+
+```bash
+adapty asa keywords add --ad-group <ad-group-id> --from-file keywords.txt
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--ad-group` | Yes | Ad group ID (UUID). The campaign is resolved from it |
+| `--text` | Yes, unless `--from-file` is used | Keyword text. Repeat for several |
+| `--from-file` | No | File with one keyword per line. Combined with any `--text` values |
+| `--bid` | No | Bid per keyword as a plain amount |
+| `--match-type` | No | `BROAD` or `EXACT`. Default: `BROAD` |
+| `--currency` | No | Currency code for the amounts in this call. Default: `USD` |
+| `--status` | No | `ACTIVE` or `PAUSED`. Default: `ACTIVE` |
+
+One invalid ID fails the whole batch before Apple is called. Apple can still reject individual keywords, and each rejection is reported with its reason.
+
+### adapty asa keywords update
+
+Change the bid, status, text, or match type of one or more keywords.
+
+```bash
+adapty asa keywords update <keyword-id> <keyword-id> --bid 2.00 --status PAUSED
+```
+
+| Argument | Description |
+|---|---|
+| `keyword-id` | Keyword ID (UUID). Pass several as extra arguments |
+
+| Flag | Description |
+|---|---|
+| `--bid` | New bid |
+| `--status` | `ACTIVE` or `PAUSED` |
+| `--match-type` | `BROAD` or `EXACT` |
+| `--text` | New keyword text. Only meaningful for a single keyword |
+| `--currency` | Currency code for the amounts in this call. Default: `USD` |
+
+One change is applied to every ID passed.
+
+## Negative keywords \{#negative-keywords\}
+
+### adapty asa negative-keywords list
+
+List negative keywords. Rows with an empty `ad_group_id` are campaign-level.
+
+```bash
+adapty asa negative-keywords list --campaign <campaign-id>
+```
+
+| Flag | Description |
+|---|---|
+| `--campaign-level-only` | Keep only campaign-level rows |
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group`, `--app`, `--campaign`, `--ad-group`, and `--search` [list filters](#list-filters).
+
+### adapty asa negative-keywords add
+
+Add negative keywords to an ad group or a campaign.
+
+```bash
+adapty asa negative-keywords add --ad-group <ad-group-id> --text free
+```
+
+Apply them to every ad group of a campaign instead:
+
+```bash
+adapty asa negative-keywords add --campaign <campaign-id> --all-ad-groups --text free
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--ad-group` | One of `--ad-group` or `--campaign` | Ad group ID (UUID). The campaign is resolved from it |
+| `--campaign` | One of `--ad-group` or `--campaign` | Campaign ID (UUID) |
+| `--text` | Yes | Keyword text. Repeat for several |
+| `--all-ad-groups` | No | Apply to every ad group of the campaign instead of the campaign itself. Requires `--campaign` |
+| `--match-type` | No | `BROAD` or `EXACT`. Default: `EXACT` |
+| `--status` | No | `ACTIVE` or `PAUSED`. Default: `ACTIVE` |
+
+`--ad-group` and `--campaign` are mutually exclusive. Pass exactly one.
+
+## Search terms \{#search-terms\}
+
+### adapty asa search-terms list
+
+List the search terms that triggered your ads. Use it to find new keywords and new negative keywords.
+
+```bash
+adapty asa search-terms list --ad-group <ad-group-id> --date-from 2026-07-01 --date-to 2026-07-31
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--date-from` | Today | Start of the reporting period (`YYYY-MM-DD`) |
+| `--date-to` | Today | End of the reporting period (`YYYY-MM-DD`) |
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group`, `--app`, `--campaign`, `--ad-group`, and `--search` [list filters](#list-filters).
+
+This command shares an analytics pool with [`asa metrics`](#metrics). See [Errors](#errors).
+
+## Ads \{#ads\}
+
+### adapty asa ads list
+
+List [ads](ads-manager-manage-ads). The `serving_state_reasons` field explains why an ad is not running.
+
+```bash
+adapty asa ads list --ad-group <ad-group-id>
+```
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group`, `--campaign`, `--ad-group`, `--search`, and `--status` [list filters](#list-filters). This list has no `--app` filter, because ads belong to ad groups.
+
+### adapty asa ads get
+
+Get details for a specific ad.
+
+```bash
+adapty asa ads get <ad-id>
+```
+
+| Argument | Description |
+|---|---|
+| `ad-id` | Ad ID (UUID) |
+
+### adapty asa ads create
+
+Create an ad in an ad group.
+
+```bash
+adapty asa ads create --ad-group <ad-group-id> --creative-id 4321 --name "Summer ad"
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--ad-group` | Yes | Ad group ID (UUID). The campaign is resolved from it |
+| `--creative-id` | Yes | Apple creative ID. See [`creatives list`](#adapty-asa-creatives-list) |
+| `--name` | Yes | Ad name |
+| `--status` | No | Initial status: `ENABLED` or `PAUSED` |
+
+### adapty asa ads update
+
+Update an existing ad.
+
+```bash
+adapty asa ads update <ad-id> --status PAUSED
+```
+
+| Argument | Description |
+|---|---|
+| `ad-id` | Ad ID (UUID) |
+
+| Flag | Description |
+|---|---|
+| `--name` | New ad name |
+| `--status` | `ENABLED` or `PAUSED` |
+
+At least one flag is required. The creative and the parent ad group are fixed at creation.
+
+## Creatives \{#creatives\}
+
+### adapty asa creatives list
+
+List the creatives available for new ads.
+
+```bash
+adapty asa creatives list --app <app-id>
+```
+
+The `creative_id` returned here is the `--creative-id` value for [`ads create`](#adapty-asa-ads-create).
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group` and `--app` [list filters](#list-filters).
+
+## Product pages \{#product-pages\}
+
+### adapty asa product-pages list
+
+List the custom product pages available to your apps.
+
+```bash
+adapty asa product-pages list --app <app-id>
+```
+
+Accepts [pagination flags](#global-flags) and the `--campaign-group` and `--app` [list filters](#list-filters).
+
+### adapty asa product-pages sync
+
+Refresh the custom product pages from App Store Connect.
+
+```bash
+adapty asa product-pages sync --adam-id 123456
+```
+
+| Flag | Description |
+|---|---|
+| `--adam-id` | Limit the refresh to one app. Omit to cover every app |
+
+The refresh is queued rather than performed immediately. A successful response also means a sync is already running or there is nothing to sync.
+
+## Automations \{#automations\}
+
+The CLI stores the rule JSON you give it — it does not build rules. See [Automations](ads-manager-automations) for what each rule type does, and [Run automation rules](developer-cli-ads-manager#run-automation-rules) for how to produce a rule file.
+
+### adapty asa automations list
+
+List [automation rules](ads-manager-automations). The `status` field is `1` for active and `0` for stopped.
+
+```bash
+adapty asa automations list
+```
+
+Accepts [pagination flags](#global-flags).
+
+### adapty asa automations get
+
+Get a specific automation rule, including its conditions and actions.
+
+```bash
+adapty asa automations get <automation-id>
+```
+
+| Argument | Description |
+|---|---|
+| `automation-id` | Automation rule ID (UUID) |
+
+### adapty asa automations create
+
+Create an automation rule from a JSON rule file.
+
+```bash
+adapty asa automations create --file rule.json
+```
+
+| Flag | Description |
+|---|---|
+| `--file` | JSON file with the rule body, or `-` to read from standard input |
+| `--run-now` | Queue the first run right after the rule is stored |
+
+`--file` is required.
+
+### adapty asa automations update
+
+Change an automation rule: stop it, rename it, or replace parts of the rule.
+
+```bash
+adapty asa automations update <automation-id> --stop
+```
+
+| Argument | Description |
+|---|---|
+| `automation-id` | Automation rule ID (UUID) |
+
+| Flag | Description |
+|---|---|
+| `--start` | Activate the rule |
+| `--stop` | Stop the rule and clear its next run |
+| `--name` | New rule name |
+| `--file` | JSON file with the parts to change, or `-` to read from standard input |
+
+`--start` and `--stop` are mutually exclusive. A file passed here must not contain `internal_id`.
+
+### adapty asa automations run
+
+Run an automation rule once, outside its schedule.
+
+```bash
+adapty asa automations run <automation-id> --dry-run
+```
+
+| Argument | Description |
+|---|---|
+| `automation-id` | Automation rule ID (UUID) |
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | Evaluate the rule and log the result without changing anything in Apple Ads |
+
+The run is queued, and the command prints a run ID. Read the outcome with [`automations runs`](#adapty-asa-automations-runs).
+
+### adapty asa automations runs
+
+List past runs of an automation rule, including dry runs.
+
+```bash
+adapty asa automations runs <automation-id>
+```
+
+| Argument | Description |
+|---|---|
+| `automation-id` | Automation rule ID (UUID) |
+
+Accepts [pagination flags](#global-flags).
+
+## Metrics \{#metrics\}
+
+### adapty asa metrics
+
+Query metrics for any level of the account over a date range.
+
+```bash
+adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--entity` | Yes | What to report on: `campaign`, `ad-group`, `keyword`, or `ad` |
+| `--date-from` | Yes | Start of the period (`YYYY-MM-DD`) |
+| `--date-to` | Yes | End of the period (`YYYY-MM-DD`) |
+| `--metric` | No | Metric name, repeatable. Omit for every metric |
+| `--group-by` | No | Break the rows down by `country`, `day`, `week`, `month`, `quarter`, or `year`. Repeatable |
+| `--by-days` | No | Renewal window in days for cohort metrics, repeatable. Maximum 16 per call. Omit for the dashboard defaults |
+| `--order-by` | No | Metric or field to sort by |
+| `--order-by-day` | No | Rank by a cohort metric at this renewal window. Must be one of the `--by-days` values |
+| `--order` | No | `asc` or `desc`. Default: `desc` |
+
+Accepts [pagination flags](#global-flags).
+
+`--metric` takes the metric names that Ads Manager tracks. See [Metrics](adapty-ads-manager-metrics) for the full list and how each one is calculated.
+
+There is no `ltv` metric. Lifetime value is a cohort metric read at a renewal window, so `--by-days` is how you ask for the day-7 or day-90 value:
+
+```bash
+adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31 --metric roas --by-days 7 --by-days 90
+```
+
+`--order-by-day` ranks the rows by one of those windows, which returns the top campaigns by day-90 ROAS in a single call.
+
+### adapty asa metrics overview
+
+Query totals for a period, bucketed by a unit of time.
+
+```bash
+adapty asa metrics overview --entity campaign --date-from 2026-07-01 --date-to 2026-07-31 --period-unit week
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--entity` | Yes | What to report on: `campaign`, `ad-group`, `keyword`, or `ad` |
+| `--date-from` | Yes | Start of the period (`YYYY-MM-DD`) |
+| `--date-to` | Yes | End of the period (`YYYY-MM-DD`) |
+| `--period-unit` | No | Bucket size: `day`, `week`, `month`, `quarter`, or `year`. Default: `day` |
+| `--metric` | No | Metric name, repeatable. Omit for every metric |
+| `--by-days` | No | Renewal window in days for cohort metrics, repeatable. Maximum 16 per call |
+
+On this command, `--metric` accepts cohort roots only — `revenue`, `roas`, and `arpu` — not their `gross_`, `proceeds_`, or `net_` variants. This command has no ordering flags and no pagination.
+
+## Errors \{#errors\}
+
+| Status | Code | Meaning |
+|---|---|---|
+| `402` | `ads_manager_subscription_required` | The company has no active Ads Manager subscription |
+| `404` | — | The entity does not exist, or it belongs to another company |
+| `409` | `cli_idempotency_in_progress` | A write with the same idempotency key is still running |
+| `422` | `cli_idempotency_key_reuse` | The same idempotency key was used with a different request body |
+| `429` | `cli_analytics_busy` | The analytics pool is busy. The wait is in the `Retry-After` header |
+| `429` | `cli_cooldown_active` | Too many rejected requests put the token into a cool-down |
+
+Metrics and the search terms list share one analytics pool per company, limited to two concurrent queries. A burst of 20 rejected requests within 5 minutes starts an escalating cool-down of 5 minutes, then 30 minutes, then 3 hours. Retrying during the pause does not extend it, but the fix is to correct the failing request rather than repeat it.

--- a/src/content/docs/developer-cli/developer-cli-ads-manager-reference.mdx
+++ b/src/content/docs/developer-cli/developer-cli-ads-manager-reference.mdx
@@ -617,6 +617,26 @@ adapty asa metrics overview --entity campaign --date-from 2026-07-01 --date-to 2
 
 On this command, `--metric` accepts cohort roots only — `revenue`, `roas`, and `arpu` — not their `gross_`, `proceeds_`, or `net_` variants. This command has no ordering flags and no pagination.
 
+## Competitors \{#competitors\}
+
+### adapty asa competitors summary
+
+Summarize the Apple Ads keywords that a set of App Store apps bid on. This returns the same competitor data as [Market Intelligence](ads-manager-market-intelligence) in the dashboard.
+
+```bash
+adapty asa competitors summary --app-ids 1668337467,6503873027
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--app-ids` | Yes | Apple App Store IDs (`adam_id`), comma-separated. Between 1 and 5 values |
+
+The reporting period and the country set are fixed on the server — the last full month, across every country. This command has no period, country, or pagination flags.
+
+The command prints three blocks: the totals for the analysis, the top apps by performance, and the most contested terms. Add `--json` for the full result, which also breaks each app's terms down by country.
+
+The first call for a set of apps can take tens of seconds while the data is prepared. Later calls for the same apps return faster.
+
 ## Errors \{#errors\}
 
 | Status | Code | Meaning |

--- a/src/content/docs/developer-cli/developer-cli-ads-manager-reference.mdx
+++ b/src/content/docs/developer-cli/developer-cli-ads-manager-reference.mdx
@@ -26,7 +26,9 @@ All `list` commands also accept pagination flags:
 | Flag | Default | Description |
 |---|---|---|
 | `--page` | `1` | Page number |
-| `--page-size` | `20` | Items per page (max: 100) |
+| `--page-size` | `100` | Items per page (max: 1000) |
+
+Ads Manager pages are larger than in the rest of the CLI. Prefer one large page over a loop of small ones.
 
 All commands that change your account accept these flags:
 
@@ -43,12 +45,14 @@ Filters narrow the query itself, not the printed page. An unfiltered `keywords l
 
 | Filter | Accepted by |
 |---|---|
-| `--campaign-group` | All lists in this table |
-| `--app` | `campaigns`, `ad-groups`, `keywords`, `negative-keywords`, `search-terms`, `product-pages`, `creatives` |
+| `--campaign-group` | `campaigns`, `ad-groups`, `keywords`, `negative-keywords`, `search-terms`, `ads`, `creatives`, `product-pages` |
+| `--app` | `campaigns`, `ad-groups`, `keywords`, `negative-keywords`, `search-terms`, `creatives`, `product-pages` |
 | `--campaign` | `ad-groups`, `keywords`, `negative-keywords`, `search-terms`, `ads` |
 | `--ad-group` | `keywords`, `negative-keywords`, `search-terms`, `ads` |
 | `--status` | `campaigns`, `ad-groups`, `ads` (`ENABLED` or `PAUSED`), `keywords` (`ACTIVE` or `PAUSED`) |
-| `--search` | All lists except `product-pages` and `creatives`. Case-insensitive substring match on the name |
+| `--search` | `campaigns`, `ad-groups`, `keywords`, `negative-keywords`, `search-terms`, `ads`. Case-insensitive substring match on the name |
+
+`adapty asa apps list`, `orgs list`, `automations list`, and `automations runs` take no filters. They accept pagination flags only.
 
 `--campaign-group`, `--app`, `--campaign`, and `--ad-group` take the UUIDs printed by the matching `list` command, and each one is repeatable:
 
@@ -93,7 +97,14 @@ List the campaign groups (Apple Ads organizations) available to your company.
 adapty asa orgs list
 ```
 
-The ID returned here is the `--org` value for [`campaigns create`](#adapty-asa-campaigns-create).
+Each row carries two identifiers, and they are not interchangeable:
+
+| Field | Used as |
+|---|---|
+| `internal_id` | The UUID that `--org` takes on [`campaigns create`](#adapty-asa-campaigns-create), and that `--campaign-group` takes as a [list filter](#list-filters) |
+| `org_id` | Apple's numeric organization ID. Both flags reject it |
+
+`--org` exists only on `campaigns create`. No list command accepts it.
 
 Accepts [pagination flags](#global-flags).
 
@@ -104,6 +115,13 @@ List the apps promoted in Apple Ads.
 ```bash
 adapty asa apps list
 ```
+
+Each row carries two identifiers, and they are not interchangeable:
+
+| Field | Used as |
+|---|---|
+| `internal_id` | The UUID that `--app` takes as a [list filter](#list-filters) |
+| `adam_id` | Apple's numeric App Store ID, taken by `--adam-id` on [`campaigns create`](#adapty-asa-campaigns-create) and [`product-pages sync`](#adapty-asa-product-pages-sync) |
 
 Accepts [pagination flags](#global-flags).
 
@@ -468,7 +486,7 @@ adapty asa product-pages sync --adam-id 123456
 |---|---|
 | `--adam-id` | Limit the refresh to one app. Omit to cover every app |
 
-The refresh is queued rather than performed immediately. A successful response also means a sync is already running or there is nothing to sync.
+The refresh is queued rather than performed immediately, and the command confirms with `Sync queued.` If the same refresh is already in flight, it reports `Already running; nothing new was queued.` instead.
 
 ## Automations \{#automations\}
 
@@ -586,9 +604,23 @@ adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31
 | `--order-by-day` | No | Rank by a cohort metric at this renewal window. Must be one of the `--by-days` values |
 | `--order` | No | `asc` or `desc`. Default: `desc` |
 
-Accepts [pagination flags](#global-flags).
+Accepts [pagination flags](#global-flags). This command takes no [list filters](#list-filters) — narrow the report by entity level and period, then match the rows against the IDs from a scoped `list` command.
 
-`--metric` takes the metric names that Ads Manager tracks. See [Metrics](adapty-ads-manager-metrics) for the full list and how each one is calculated.
+Each row is one entity, aggregated on the server and sorted by `--order-by`. A top-N question is therefore a single call — set `--order-by` and `--page-size N` rather than paging through the results and adding them up:
+
+```bash
+adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31 --order-by spend --page-size 5
+```
+
+`--metric` takes the metric names that Ads Manager tracks, in dashboard nomenclature — for example `spend`, `taps`, or `gross_roas`. See [Metrics](adapty-ads-manager-metrics) for the full list and how each one is calculated. A name that does not exist fails with the valid names listed in the error.
+
+The length of the reporting period is capped by the coarsest `--group-by` value. To report on a longer period, coarsen the grouping rather than splitting the request into several calls:
+
+| Coarsest `--group-by` | Maximum period |
+|---|---|
+| `day`, or no period grouping | 90 days |
+| `week` | 180 days |
+| `month` and coarser | 365 days |
 
 There is no `ltv` metric. Lifetime value is a cohort metric read at a renewal window, so `--by-days` is how you ask for the day-7 or day-90 value:
 
@@ -615,7 +647,17 @@ adapty asa metrics overview --entity campaign --date-from 2026-07-01 --date-to 2
 | `--metric` | No | Metric name, repeatable. Omit for every metric |
 | `--by-days` | No | Renewal window in days for cohort metrics, repeatable. Maximum 16 per call |
 
-On this command, `--metric` accepts cohort roots only — `revenue`, `roas`, and `arpu` — not their `gross_`, `proceeds_`, or `net_` variants. This command has no ordering flags and no pagination.
+This command returns the totals for the whole entity level plus a per-period series, so it answers "how much did I spend or earn overall" in one call. It has no ordering flags and no pagination.
+
+On this command, `--metric` accepts cohort roots only — `revenue`, `roas`, and `arpu` — not their `gross_`, `proceeds_`, or `net_` variants.
+
+The length of the reporting period is capped by `--period-unit`:
+
+| `--period-unit` | Maximum period |
+|---|---|
+| `day` | 90 days |
+| `week` | 180 days |
+| `month` and coarser | 365 days |
 
 ## Competitors \{#competitors\}
 
@@ -648,4 +690,6 @@ The first call for a set of apps can take tens of seconds while the data is prep
 | `429` | `cli_analytics_busy` | The analytics pool is busy. The wait is in the `Retry-After` header |
 | `429` | `cli_cooldown_active` | Too many rejected requests put the token into a cool-down |
 
-Metrics and the search terms list share one analytics pool per company, limited to two concurrent queries. A burst of 20 rejected requests within 5 minutes starts an escalating cool-down of 5 minutes, then 30 minutes, then 3 hours. Retrying during the pause does not extend it, but the fix is to correct the failing request rather than repeat it.
+Metrics and the search terms list share one analytics budget per company: 5 calls per minute, and at most 2 in any 10 seconds. A burst of 20 rejected requests within 5 minutes starts an escalating cool-down of 5 minutes, then 30 minutes, then 3 hours. Retrying during the pause does not extend it, but the fix is to correct the failing request rather than repeat it.
+
+The CLI handles short waits for you. On a `429` that is not a cool-down, if `Retry-After` is 60 seconds or less, the command waits for that long and retries once, reporting the wait on standard error.

--- a/src/content/docs/developer-cli/developer-cli-ads-manager-skill.mdx
+++ b/src/content/docs/developer-cli/developer-cli-ads-manager-skill.mdx
@@ -1,0 +1,53 @@
+---
+title: "Manage Apple Ads with an AI coding tool"
+description: "Install the ads-manager skill so Claude Code, Copilot CLI, Codex, or Gemini CLI can run your Apple Ads campaigns through the Adapty CLI."
+metadataTitle: "Ads Manager AI Skill | Adapty Docs"
+---
+
+import AdsManagerSkill from '@site/src/components/reusable/AdsManagerSkill.mdx';
+
+The `ads-manager` skill lets an AI coding tool operate your Apple Ads account through the [Adapty CLI](developer-cli-ads-manager). Ask it a question in plain language, and it works out which commands answer it, reads the account first, and proposes the write before anything reaches Apple.
+
+A skill is a set of instructions your AI tool loads on demand. This one carries the parts of the Ads Manager surface that are easy to get wrong: which identifier each flag accepts, which filter each list takes, how many keywords fit in a batch, and which calls cost money.
+
+## What it handles
+
+- **Reading performance**: Picks the single call that answers a question instead of paging through results. It knows that a top-N question is one ordered call, and that counting entities needs no metrics call at all.
+- **Structural changes**: Creates and updates campaigns, ad groups, ads, and keywords in the right order, reading the parent entity before writing the child.
+- **Keyword work**: Adds and re-bids keywords in batches, and harvests search terms into keywords and negative keywords.
+- **Automations**: Sets up rule-based automations and dry-runs them before they touch live bids.
+- **Competitor research**: Pulls the keywords competing apps bid on.
+
+## What it will not do
+
+The skill treats every write as irreversible, because it is — the CLI has no delete, and changes reach Apple within seconds.
+
+- It reads before it writes, rather than guessing an ID or a budget.
+- It asks before any command that spends money, and it leaves the CLI's own confirmation prompt in place when you are the one running the command.
+- It pins an idempotency key on each write in a chain, so a re-run after an unclear result does not create a second campaign.
+- It prefers small batches, so a partial rejection from Apple stays easy to read.
+
+:::note
+The skill recommends and prepares commands. Reading metrics and dry runs cost nothing, but you stay responsible for approving anything that changes a live ad account.
+:::
+
+## Install the skill
+
+<AdsManagerSkill />
+
+## How it differs from the AI Agent
+
+Adapty Ads Manager also has a built-in [AI Agent](ads-manager-ai-agent) in the dashboard. The two answer different needs:
+
+| | AI Agent | ads-manager skill |
+|---|---|---|
+| Where it runs | The Adapty dashboard | Your terminal, in your AI coding tool |
+| What it does | Analyzes and recommends | Analyzes, recommends, and runs the commands |
+| Setup | None | Adapty CLI plus the skill |
+
+Use the AI Agent to ask what is happening in your account. Use the skill when you want the change carried out as well.
+
+## What's next
+
+- [Manage Ads Manager from the CLI](developer-cli-ads-manager) — the same tasks by hand, without an AI tool.
+- [Ads Manager commands](developer-cli-ads-manager-reference) — every command with its arguments, flags, and accepted values.

--- a/src/content/docs/developer-cli/developer-cli-ads-manager.mdx
+++ b/src/content/docs/developer-cli/developer-cli-ads-manager.mdx
@@ -1,0 +1,126 @@
+---
+title: "Manage Ads Manager from the CLI"
+description: "Run Apple Ads campaigns, keywords, and automation rules from the terminal with the Adapty Developer CLI."
+metadataTitle: "Ads Manager in the Developer CLI | Adapty Docs"
+---
+
+The Adapty CLI can manage your [Ads Manager](adapty-ads-manager) account from the terminal, under the `adapty asa` topic. It covers campaigns, ad groups, keywords, ads, product pages, automation rules, and metrics.
+
+Use it for the work that a browser makes slow: adding several hundred keywords from a file, pulling metrics into a script or a spreadsheet, and running the same setup across several campaigns. For everything else, the [dashboard](https://app.adapty.io) remains faster.
+
+:::warning
+The CLI cannot delete anything. Campaigns, ads, and automation rules can be created, updated, and paused from the terminal, but deleting them is only possible in the dashboard.
+:::
+
+## Before you start
+
+Ads Manager commands use the same installation and login as the rest of the CLI. If you have not set that up, follow steps 1 and 2 of the [quickstart guide](developer-cli-quickstart).
+
+Two further conditions apply to every `adapty asa` command:
+
+- **A connected Apple Ads account**: Connect it with `adapty asa connect`, or in the dashboard as described in [Get started with Adapty Ads Manager](adapty-ads-manager-get-started).
+- **An active Ads Manager subscription**: Without one, every command fails with `402 ads_manager_subscription_required`.
+
+One command reports both:
+
+```bash
+adapty asa whoami
+```
+
+Three behaviors differ from the rest of the CLI:
+
+- **There is no `--app` flag**: The scope is the company your token belongs to. `--app` exists on some `list` commands as a filter only.
+- **Writes reach Apple directly**: Each command that changes your account prints the request body and asks for confirmation before sending it. There is no staging step.
+- **Reads are cheap, writes are not**: Run `list` commands and `--dry-run` freely. Treat everything else as irreversible.
+
+To skip the confirmation prompt in a script, pass `--yes`. Under `--json` or in a pipe, a write command refuses instead of waiting for an answer that will never arrive, so `--yes` is required there.
+
+## Find the IDs you need
+
+Every command takes UUIDs, and every UUID comes from a `list` command. Work down the hierarchy:
+
+```bash
+adapty asa orgs list
+adapty asa campaigns list --campaign-group <campaign-group-id>
+adapty asa ad-groups list --campaign <campaign-id>
+```
+
+Scope each read with a filter. Filters narrow the query rather than the printed page, so a scoped read is cheap while an unscoped one pages through the whole account. `adapty asa keywords list` without `--ad-group` is the widest read in the topic.
+
+These lists return metadata only. Performance numbers come from [`asa metrics`](#pull-metrics-into-a-script).
+
+## Add keywords in bulk
+
+Adding keywords one at a time is the main reason to leave the dashboard. Put one keyword per line in a text file:
+
+```bash
+adapty asa keywords add --ad-group <ad-group-id> --from-file keywords.txt --bid 1.20 --match-type EXACT
+```
+
+Keywords are applied as a batch of at most 100 per call. Split larger lists across several calls.
+
+Two kinds of failure are possible, and they behave differently. An invalid ID fails the whole batch before Apple is called, so nothing is applied. Apple can also reject individual keywords — the rest are still added, and each rejection is reported with its reason. Check the summary line rather than the exit code alone.
+
+Start with a handful of keywords and check the result before sending a full file.
+
+## Pull metrics into a script
+
+`asa metrics` reports on any level of the account over a date range. Add `--json` to get machine-readable output:
+
+```bash
+adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31 --metric spend --metric roas --json
+```
+
+`--metric` takes the names that Ads Manager tracks. See [Metrics](adapty-ads-manager-metrics) for the full list.
+
+Cohort metrics work differently from the rest. There is no `ltv` metric, because lifetime value is read at a renewal window rather than on a date. Ask for the window instead:
+
+```bash
+adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31 --metric roas --by-days 7 --by-days 90 --order-by-day 90
+```
+
+This returns your campaigns ranked by day-90 ROAS. Up to 16 windows fit in one call.
+
+Metrics and the search terms list share one analytics pool per company, limited to two concurrent queries. A busy pool answers `429` with the wait in the `Retry-After` header. Run these queries in sequence rather than in parallel.
+
+## Run automation rules \{#run-automation-rules\}
+
+The CLI does not build [automation rules](ads-manager-automations) — it stores the JSON you give it. The fastest way to get a valid rule file is to build one rule in the dashboard, then read it back:
+
+```bash
+adapty asa automations get <automation-id> --json > rule.json
+```
+
+Edit that file and use it as the template for new rules:
+
+```bash
+adapty asa automations create --file rule.json
+```
+
+When you pass a file to `automations update`, remove the `internal_id` field first — the update is rejected if it is present.
+
+Test a rule before letting it change bids:
+
+```bash
+adapty asa automations run <automation-id> --dry-run
+```
+
+A dry run evaluates the conditions and logs what the rule would do without touching Apple Ads. Runs are queued rather than performed immediately, so the command prints a run ID and the outcome appears in `adapty asa automations runs`.
+
+## Re-run scripts safely
+
+Every write sends an idempotency key. The CLI generates one per invocation and retries once after a network error, so a request that failed in transit is never applied twice.
+
+In a script, pin the key yourself so the whole pipeline can be re-run:
+
+```bash
+adapty asa campaigns create --org <campaign-group-id> --name "Winter push" --adam-id 123456 --country US --daily-budget 50 --idempotency-key winter-push-2026 --yes
+```
+
+Re-running the same command within 24 hours returns the stored result and prints `Already applied earlier` instead of creating a second campaign. The same key with a different body fails with `422`, which catches an edited script that reuses a key by mistake.
+
+## What's next
+
+- [Ads Manager commands](developer-cli-ads-manager-reference) — every command with its arguments, flags, and accepted values.
+- [Automations](ads-manager-automations) — what each rule type does and which actions it can take.
+- [Metrics](adapty-ads-manager-metrics) — the metric names accepted by `--metric` and how each one is calculated.

--- a/src/content/docs/developer-cli/developer-cli-ads-manager.mdx
+++ b/src/content/docs/developer-cli/developer-cli-ads-manager.mdx
@@ -4,9 +4,9 @@ description: "Run Apple Ads campaigns, keywords, and automation rules from the t
 metadataTitle: "Ads Manager in the Developer CLI | Adapty Docs"
 ---
 
-The Adapty CLI can manage your [Ads Manager](adapty-ads-manager) account from the terminal, under the `adapty asa` topic. It covers campaigns, ad groups, keywords, ads, product pages, automation rules, and metrics.
+The Adapty CLI can manage your [Ads Manager](adapty-ads-manager) account from the terminal, under the `adapty asa` topic. It covers campaigns, ad groups, keywords, ads, product pages, automation rules, metrics, and competitor research.
 
-Use it for the work that a browser makes slow: adding several hundred keywords from a file, pulling metrics into a script or a spreadsheet, and running the same setup across several campaigns. For everything else, the [dashboard](https://app.adapty.io) remains faster.
+Use it for the work that a browser makes slow: giving an AI agent live access to your ad performance, adding several hundred keywords from a file, and running the same setup across several campaigns. For everything else, the [dashboard](https://app.adapty.io) remains faster.
 
 :::warning
 The CLI cannot delete anything. Campaigns, ads, and automation rules can be created, updated, and paused from the terminal, but deleting them is only possible in the dashboard.
@@ -15,6 +15,8 @@ The CLI cannot delete anything. Campaigns, ads, and automation rules can be crea
 ## Before you start
 
 Ads Manager commands use the same installation and login as the rest of the CLI. If you have not set that up, follow steps 1 and 2 of the [quickstart guide](developer-cli-quickstart).
+
+### Prerequisites
 
 Two further conditions apply to every `adapty asa` command:
 
@@ -27,7 +29,7 @@ One command reports both:
 adapty asa whoami
 ```
 
-Three behaviors differ from the rest of the CLI:
+### Differences from the rest of the CLI
 
 - **There is no `--app` flag**: The scope is the company your token belongs to. `--app` exists on some `list` commands as a filter only.
 - **Writes reach Apple directly**: Each command that changes your account prints the request body and asks for confirmation before sending it. There is no staging step.
@@ -47,7 +49,7 @@ adapty asa ad-groups list --campaign <campaign-id>
 
 Scope each read with a filter. Filters narrow the query rather than the printed page, so a scoped read is cheap while an unscoped one pages through the whole account. `adapty asa keywords list` without `--ad-group` is the widest read in the topic.
 
-These lists return metadata only. Performance numbers come from [`asa metrics`](#pull-metrics-into-a-script).
+These lists return metadata only. Performance numbers come from [`asa metrics`](#query-metrics-from-agents-and-scripts).
 
 ## Add keywords in bulk
 
@@ -63,9 +65,9 @@ Two kinds of failure are possible, and they behave differently. An invalid ID fa
 
 Start with a handful of keywords and check the result before sending a full file.
 
-## Pull metrics into a script
+## Query metrics from agents and scripts
 
-`asa metrics` reports on any level of the account over a date range. Add `--json` to get machine-readable output:
+`asa metrics` reports on any level of the account over a date range. Add `--json` so an AI agent or a script can consume the result directly:
 
 ```bash
 adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31 --metric spend --metric roas --json
@@ -82,6 +84,18 @@ adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31
 This returns your campaigns ranked by day-90 ROAS. Up to 16 windows fit in one call.
 
 Metrics and the search terms list share one analytics pool per company, limited to two concurrent queries. A busy pool answers `429` with the wait in the `Retry-After` header. Run these queries in sequence rather than in parallel.
+
+## Check competitor keywords
+
+One command returns the keywords that competing apps bid on, for up to five App Store apps at a time:
+
+```bash
+adapty asa competitors summary --app-ids 1668337467,6503873027 --json
+```
+
+The period and the countries are fixed on the server — the last full month, across every country — so the command has no flags beyond the app IDs. The first call for a set of apps can take tens of seconds.
+
+Use this to pull competitor keyword data into a report on a schedule. To filter the results, compare countries side by side, or add the keywords you find straight to a campaign, use [Market Intelligence](ads-manager-market-intelligence) in the dashboard instead.
 
 ## Run automation rules \{#run-automation-rules\}
 

--- a/src/content/docs/developer-cli/developer-cli-ads-manager.mdx
+++ b/src/content/docs/developer-cli/developer-cli-ads-manager.mdx
@@ -83,7 +83,13 @@ adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31
 
 This returns your campaigns ranked by day-90 ROAS. Up to 16 windows fit in one call.
 
-Metrics and the search terms list share one analytics pool per company, limited to two concurrent queries. A busy pool answers `429` with the wait in the `Retry-After` header. Run these queries in sequence rather than in parallel.
+Each row is one entity, already aggregated and sorted on the server. A "top five campaigns by spend" question is therefore one call, not a pass over every page:
+
+```bash
+adapty asa metrics --entity campaign --date-from 2026-07-01 --date-to 2026-07-31 --order-by spend --page-size 5
+```
+
+Metrics and the search terms list share one analytics budget per company: 5 calls per minute, and at most 2 in any 10 seconds. Ask a narrow question once rather than polling. The reporting period is also capped by how finely you group it — 90 days by day, 180 by week, 365 by month — so widen a report by coarsening `--group-by`, not by splitting it into more calls.
 
 ## Check competitor keywords
 
@@ -135,6 +141,7 @@ Re-running the same command within 24 hours returns the stored result and prints
 
 ## What's next
 
+- [Manage Apple Ads with an AI coding tool](developer-cli-ads-manager-skill) — install the `ads-manager` skill so Claude Code, Copilot CLI, Codex, or Gemini CLI can run these commands for you.
 - [Ads Manager commands](developer-cli-ads-manager-reference) — every command with its arguments, flags, and accepted values.
 - [Automations](ads-manager-automations) — what each rule type does and which actions it can take.
 - [Metrics](adapty-ads-manager-metrics) — the metric names accepted by `--metric` and how each one is calculated.

--- a/src/content/docs/developer-cli/developer-cli-authentication.mdx
+++ b/src/content/docs/developer-cli/developer-cli-authentication.mdx
@@ -11,6 +11,8 @@ Using an AI assistant? An [Adapty CLI skill](https://github.com/adaptyteam/adapt
 
 The CLI requires authentication to call the Adapty API.
 
+One login covers the whole CLI. The [Ads Manager commands](developer-cli-ads-manager) reach a different service, but they use the same stored token — there is no second login step.
+
 ## Log in
 
 To log in:

--- a/src/content/docs/developer-cli/developer-cli-authentication.mdx
+++ b/src/content/docs/developer-cli/developer-cli-authentication.mdx
@@ -5,10 +5,6 @@ metadataTitle: "Developer CLI Authentication | Adapty Docs"
 keywords: ['cli', 'developer', 'authentication', 'mcp']
 ---
 
-:::link
-Using an AI assistant? An [Adapty CLI skill](https://github.com/adaptyteam/adapty-cli/tree/main/skills/adapty-cli) is available to help LLMs work with the CLI.
-:::
-
 The CLI requires authentication to call the Adapty API.
 
 One login covers the whole CLI. The [Ads Manager commands](developer-cli-ads-manager) reach a different service, but they use the same stored token — there is no second login step.

--- a/src/content/docs/developer-cli/developer-cli-quickstart.mdx
+++ b/src/content/docs/developer-cli/developer-cli-quickstart.mdx
@@ -126,7 +126,7 @@ The store product IDs you link here cannot be changed after creation. To use dif
 
 The command returns a `<product-id>`.
 
-If you also sell this product on the web through Stripe or Paddle, add those IDs to the same command. See [products create](developer-cli-reference#adapty-products-create) in the full reference.
+If you also sell this product on the web through Stripe or Paddle, add those IDs to the same command. See [products create](developer-cli-reference#adapty-products-create) in the command reference.
 
 ## 6. Create a paywall
 
@@ -169,4 +169,4 @@ All entities are now visible in the [Adapty dashboard](https://app.adapty.io). N
 
 - [Design your paywall](adapty-paywall-builder) — use the no-code Paywall Builder to add visuals, layout, and copy to the paywall you just created.
 - [Integrate the Adapty SDK](quickstart-sdk) — add the SDK to your app to fetch and display the placement.
-- Route different user [segments](segments) to different paywalls — see [`placements update`](developer-cli-reference#adapty-placements-update) and [`segments list`](developer-cli-reference#adapty-segments-list) in the full reference.
+- Route different user [segments](segments) to different paywalls — see [`placements update`](developer-cli-reference#adapty-placements-update) and [`segments list`](developer-cli-reference#adapty-segments-list) in the command reference.

--- a/src/content/docs/developer-cli/developer-cli-quickstart.mdx
+++ b/src/content/docs/developer-cli/developer-cli-quickstart.mdx
@@ -8,10 +8,6 @@ keywords: ['cli', 'developer cli', 'mcp']
 import Tabs from '@site/src/components/Tabs.astro';
 import TabItem from '@site/src/components/TabItem.astro';
 
-:::link
-Using an AI assistant? An [Adapty CLI skill](https://github.com/adaptyteam/adapty-cli/tree/main/skills/adapty-cli) is available to help LLMs work with the CLI.
-:::
-
 The Adapty CLI lets you set up your app configuration entirely from the command line. Use it as an alternative to the [dashboard quickstart](integrate-payments) if you prefer terminal tooling or [MCP clients](https://github.com/adaptyteam/adapty-cli/tree/main/skills/adapty-cli).
 
 :::note

--- a/src/content/docs/developer-cli/developer-cli-reference.mdx
+++ b/src/content/docs/developer-cli/developer-cli-reference.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Full reference for the Adapty Developer CLI"
-description: "Complete reference for all Adapty Developer CLI commands."
-metadataTitle: "Developer CLI Full Reference | Adapty Docs"
+title: "Command reference for the Adapty Developer CLI"
+description: "Reference for the Adapty Developer CLI commands that configure apps, products, paywalls, and placements."
+metadataTitle: "Developer CLI Command Reference | Adapty Docs"
 keywords: ['cli', 'developer', 'reference', 'commands', 'mcp']
 ---
 
@@ -9,7 +9,7 @@ keywords: ['cli', 'developer', 'reference', 'commands', 'mcp']
 Using an AI assistant? An [Adapty CLI skill](https://github.com/adaptyteam/adapty-cli/tree/main/skills/adapty-cli) is available to help LLMs work with the CLI.
 :::
 
-This article lists all Adapty CLI commands with their arguments, flags, and accepted values.
+This article lists the Adapty CLI commands that configure your account — apps, access levels, products, paywalls, placements, and segments — with their arguments, flags, and accepted values. For Apple Ads campaigns, see [Ads Manager commands](developer-cli-ads-manager-reference).
 
 :::link
 For authentication setup and token management, see [Authentication](developer-cli-authentication).

--- a/src/content/docs/developer-cli/developer-cli-reference.mdx
+++ b/src/content/docs/developer-cli/developer-cli-reference.mdx
@@ -5,10 +5,6 @@ metadataTitle: "Developer CLI Command Reference | Adapty Docs"
 keywords: ['cli', 'developer', 'reference', 'commands', 'mcp']
 ---
 
-:::link
-Using an AI assistant? An [Adapty CLI skill](https://github.com/adaptyteam/adapty-cli/tree/main/skills/adapty-cli) is available to help LLMs work with the CLI.
-:::
-
 This article lists the Adapty CLI commands that configure your account — apps, access levels, products, paywalls, placements, and segments — with their arguments, flags, and accepted values. For Apple Ads campaigns, see [Ads Manager commands](developer-cli-ads-manager-reference).
 
 :::link

--- a/src/content/docs/developer-cli/developer-cli.mdx
+++ b/src/content/docs/developer-cli/developer-cli.mdx
@@ -7,7 +7,7 @@ keywords: ['cli', 'developer', 'command line', 'mcp']
 
 import CustomDocCardList from '@site/src/components/CustomDocCardList';
 
-<CustomDocCardList ids={['developer-cli-quickstart', 'developer-cli-authentication', 'developer-cli-reference']} />
+<CustomDocCardList ids={['developer-cli-quickstart', 'developer-cli-authentication', 'developer-cli-reference', 'developer-cli-ads-manager']} />
 
 The **Adapty Developer CLI** is a command-line tool for managing your Adapty account without opening the Dashboard. It provides the main configuration capabilities, accessible from your terminal or automated environments.
 
@@ -18,6 +18,7 @@ The **Adapty Developer CLI** is a command-line tool for managing your Adapty acc
 - Set up products and map them to App Store and Google Play store IDs
 - Create paywalls and assign products to them
 - Configure placements to fetch paywalls via the SDK
+- Run Apple Ads campaigns, keywords, and automation rules through [Ads Manager](developer-cli-ads-manager)
 
 :::link
 Using an AI assistant or MCP client? An [Adapty CLI skill](https://github.com/adaptyteam/adapty-cli/tree/main/skills/adapty-cli) is available to help LLMs work with the CLI.

--- a/src/content/docs/developer-cli/developer-cli.mdx
+++ b/src/content/docs/developer-cli/developer-cli.mdx
@@ -19,7 +19,3 @@ The **Adapty Developer CLI** is a command-line tool for managing your Adapty acc
 - Create paywalls and assign products to them
 - Configure placements to fetch paywalls via the SDK
 - Run Apple Ads campaigns, keywords, and automation rules through [Ads Manager](developer-cli-ads-manager)
-
-:::link
-Using an AI assistant or MCP client? An [Adapty CLI skill](https://github.com/adaptyteam/adapty-cli/tree/main/skills/adapty-cli) is available to help LLMs work with the CLI.
-:::

--- a/src/content/docs/version-3.0/adapty-ads-manager-get-started.mdx
+++ b/src/content/docs/version-3.0/adapty-ads-manager-get-started.mdx
@@ -76,3 +76,4 @@ After that, Adapty will start syncing your historical data from Apple Ads. You c
 After you've successfully synced your transaction data, proceed with learning how to:
 - [Manage your campaigns, ad groups, and keywords](ads-manager)
 - [Set up automation rules to adjust bids based on the campaign performance](ads-manager-automations)
+- [Work with your account from the terminal or an AI coding tool](developer-cli-ads-manager)

--- a/src/content/docs/version-3.0/adapty-ads-manager-metrics.mdx
+++ b/src/content/docs/version-3.0/adapty-ads-manager-metrics.mdx
@@ -7,6 +7,10 @@ keywords: ['adapty ads manager', 'adapty search ads', 'apple ads', 'asa']
 
 Adapty Ads Manager provides comprehensive metrics to measure campaign performance and user behavior.
 
+:::tip
+The metric names on this page are also accepted by the Adapty CLI, which returns them as JSON for any level of the account — see [Ads Manager commands](developer-cli-ads-manager-reference#metrics).
+:::
+
 ## Performance
 
 | Metric | Description                                                                                                                                                                                    |

--- a/src/content/docs/version-3.0/adapty-ads-manager.mdx
+++ b/src/content/docs/version-3.0/adapty-ads-manager.mdx
@@ -22,6 +22,7 @@ With Adapty Ads Manager, you get:
 - **[Rule-based automations](ads-manager-automations)**: Manage the full keyword lifecycle
 - **[Market Intelligence](ads-manager-market-intelligence)**: Competitor keyword strategies across 50+ countries
 - **[CPP A/B Tests](ads-manager-cpp-ab-tests)**: Compare custom product pages head-to-head and find the best performer
+- **[CLI](developer-cli-ads-manager)**: Manage campaigns, keywords, and automation rules from the terminal, and let AI agents read your metrics and act on them
 
 <CustomDocCardList ids={['adapty-ads-manager-get-started', 'ads-manager-overview', 'ads-manager-ai-agent', 'adapty-ads-manager-analytics', 'ads-manager-create-campaign', 'ads-manager-create-ad-group', 'ads-manager-manage-keywords', 'ads-manager-automations', 'ads-manager-market-intelligence', 'ads-manager-cpp-ab-tests']} />
 
@@ -37,4 +38,6 @@ With its easy implementation and smooth user experience, you can manage everythi
 
 ## Get started
 
-To get started with Adapty Ads Manager, follow the [guide](adapty-ads-manager-get-started), and you're all set to explore
+To get started with Adapty Ads Manager, follow the [guide](adapty-ads-manager-get-started). It covers the two steps you need: installing the Adapty SDK and connecting your Apple Ads account.
+
+You can also manage the same account from the terminal — see [Manage Ads Manager from the CLI](developer-cli-ads-manager).

--- a/src/content/docs/version-3.0/adapty-ads-manager.mdx
+++ b/src/content/docs/version-3.0/adapty-ads-manager.mdx
@@ -22,7 +22,7 @@ With Adapty Ads Manager, you get:
 - **[Rule-based automations](ads-manager-automations)**: Manage the full keyword lifecycle
 - **[Market Intelligence](ads-manager-market-intelligence)**: Competitor keyword strategies across 50+ countries
 - **[CPP A/B Tests](ads-manager-cpp-ab-tests)**: Compare custom product pages head-to-head and find the best performer
-- **[CLI](developer-cli-ads-manager)**: Manage campaigns, keywords, and automation rules from the terminal, and let AI agents read your metrics and act on them
+- **[CLI](developer-cli-ads-manager)**: Manage campaigns, keywords, and automation rules from the terminal, and let AI coding tools read your metrics and act on them through the [ads-manager skill](developer-cli-ads-manager-skill)
 
 <CustomDocCardList ids={['adapty-ads-manager-get-started', 'ads-manager-overview', 'ads-manager-ai-agent', 'adapty-ads-manager-analytics', 'ads-manager-create-campaign', 'ads-manager-create-ad-group', 'ads-manager-manage-keywords', 'ads-manager-automations', 'ads-manager-market-intelligence', 'ads-manager-cpp-ab-tests']} />
 

--- a/src/content/docs/version-3.0/ads-manager-ai-agent.mdx
+++ b/src/content/docs/version-3.0/ads-manager-ai-agent.mdx
@@ -10,6 +10,10 @@ It draws on your full funnel — impression, install, trial, subscription, and r
 
 The agent is advisory: it analyzes your account and recommends what to do, but does not change campaigns, bids, or budgets for you.
 
+:::tip
+To have an AI tool carry out the changes as well as recommend them, install the [ads-manager skill](developer-cli-ads-manager-skill) in Claude Code, Copilot CLI, Codex, or Gemini CLI. It works through the Adapty CLI in your terminal, so it can act on your account.
+:::
+
 ## What you can ask
 
 Ask the agent about any part of your Apple Ads account. The agent can:

--- a/src/content/docs/version-3.0/ads-manager-automations.mdx
+++ b/src/content/docs/version-3.0/ads-manager-automations.mdx
@@ -22,6 +22,10 @@ There are four types of automation rules, one for each level of your account str
 
 To start from a prebuilt rule instead of building one from scratch, click **Templates** in the Automations header. Templates are available for keyword, search term, and campaign rules — ad group rules don't have any yet.
 
+:::tip
+Rules can also be managed from the terminal, including a dry run that evaluates a rule without changing anything in Apple Ads — see [Ads Manager commands](developer-cli-ads-manager-reference#automations).
+:::
+
 ## Explore logs
 
 The **Logs** tab shows a complete history of all rule executions, so you can track performance and troubleshoot issues.

--- a/src/content/docs/version-3.0/ads-manager-create-campaign.mdx
+++ b/src/content/docs/version-3.0/ads-manager-create-campaign.mdx
@@ -82,6 +82,10 @@ To create a campaign:
    <ZoomImage id="asa-campaign-wizard-confirm.webp" width="700px" alt="Confirm and review step" />
 8. Proceed to [configure the ad group](ads-manager-create-ad-group). Campaigns can't run without ad groups — they determine the audience and/or keywords.
 
+:::tip
+Campaigns can also be created and updated from the terminal, which is useful for repeating the same setup across several campaigns — see [Ads Manager commands](developer-cli-ads-manager-reference#campaigns).
+:::
+
 ## Edit campaigns
 
 To edit any created campaign:

--- a/src/content/docs/version-3.0/ads-manager-manage-keywords.mdx
+++ b/src/content/docs/version-3.0/ads-manager-manage-keywords.mdx
@@ -146,6 +146,10 @@ Edits to keywords made directly in Apple Ads sync automatically to Adapty Ads Ma
 
 <ZoomImage id="edit-keywords.webp" width="500px" />
 
+:::tip
+To add or re-bid keywords in larger batches, use the Adapty CLI. It reads keywords from a file and applies up to 100 per call — see [Ads Manager commands](developer-cli-ads-manager-reference#keywords).
+:::
+
 ## Bulk actions
 
 You can perform bulk actions on multiple keywords to save time and manage your keywords more efficiently.

--- a/src/content/docs/version-3.0/ads-manager-market-intelligence.mdx
+++ b/src/content/docs/version-3.0/ads-manager-market-intelligence.mdx
@@ -16,6 +16,10 @@ Use it to:
 - **Enter new markets with data**: Check which keywords competitors run in a country before you spend a dollar there.
 - **Discover competitors you've missed**: Search by keyword to see who ranks organically for terms in your category and add them to your analysis.
 
+:::tip
+To pull this data into a report on a schedule, the Adapty CLI returns it for up to five apps in one command — see [Ads Manager commands](developer-cli-ads-manager-reference#competitors).
+:::
+
 ## Run a Market Intelligence analysis
 
 ### 1. Select your app

--- a/src/data/sidebars/api.json
+++ b/src/data/sidebars/api.json
@@ -22,7 +22,24 @@
       {
         "type": "doc",
         "id": "developer-cli-reference",
-        "label": "Full reference"
+        "label": "Command reference"
+      },
+      {
+        "type": "category",
+        "label": "Ads Manager",
+        "collapsible": true,
+        "collapsed": true,
+        "link": {
+          "type": "doc",
+          "id": "developer-cli-ads-manager"
+        },
+        "items": [
+          {
+            "type": "doc",
+            "id": "developer-cli-ads-manager-reference",
+            "label": "Commands"
+          }
+        ]
       }
     ]
   },

--- a/src/data/sidebars/api.json
+++ b/src/data/sidebars/api.json
@@ -38,6 +38,11 @@
             "type": "doc",
             "id": "developer-cli-ads-manager-reference",
             "label": "Commands"
+          },
+          {
+            "type": "doc",
+            "id": "developer-cli-ads-manager-skill",
+            "label": "AI coding tools"
           }
         ]
       }

--- a/src/data/sidebars/tutorial.json
+++ b/src/data/sidebars/tutorial.json
@@ -1212,6 +1212,11 @@
         "type": "doc",
         "label": "Settings",
         "id": "ads-manager-settings"
+      },
+      {
+        "type": "link",
+        "label": "Command line interface",
+        "href": "/docs/developer-cli-ads-manager"
       }
     ]
   },

--- a/src/data/sidebars/tutorial.json
+++ b/src/data/sidebars/tutorial.json
@@ -1215,7 +1215,7 @@
       },
       {
         "type": "link",
-        "label": "Command line interface",
+        "label": "CLI",
         "href": "/docs/developer-cli-ads-manager"
       }
     ]


### PR DESCRIPTION
Documents the `adapty asa` command topic in two new pages:

- **Manage Ads Manager from the CLI** — task guide
- **Ads Manager commands** — reference for all 34 commands, nested under the guide

Also renames "Full reference" to "Command reference", removes the CLI skill callout from the Developer CLI articles, and cross-links both surfaces from the Ads Manager section.

Hold until the `asa` commands ship to npm.