### PR TITLE
Fix the skill install commands for a two-skill repo

### DIFF
--- a/src/components/reusable/AdaptySdkIntegrationSkill.mdx
+++ b/src/components/reusable/AdaptySdkIntegrationSkill.mdx
@@ -8,6 +8,8 @@ The [adapty-sdk-integration skill](https://github.com/adaptyteam/adapty-sdk-inte
 
 To install, pick the form for your tool. The full list is in the [skill README](https://github.com/adaptyteam/adapty-sdk-integration-skill).
 
+The repository holds two skills — `adapty-sdk-integration` and `ads-manager`, which runs Apple Search Ads through the Adapty CLI. Each command below installs both.
+
 **Claude Code**
 
 ```
@@ -18,7 +20,8 @@ claude plugin install adapty-sdk-integration@adapty
 **GitHub Copilot CLI**
 
 ```
-gh skill install adaptyteam/adapty-sdk-integration-skill
+git clone https://github.com/adaptyteam/adapty-sdk-integration-skill.git
+cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/
 ```
 
 **Gemini CLI**
@@ -30,10 +33,12 @@ gemini skills install https://github.com/adaptyteam/adapty-sdk-integration-skill
 **OpenAI Codex or any other tool** — use the [skills CLI](https://skills.sh) (note that skills installed this way don't update automatically):
 
 ```
-npx skills add adaptyteam/adapty-sdk-integration-skill
+npx skills add adaptyteam/adapty-sdk-integration-skill --all
 ```
 
-Alternatively, clone the repo and copy `skills/adapty-sdk-integration/` into your tool's skills directory.
+`--all` installs both skills into every agent it detects. Without it, the CLI asks which of the two you want.
+
+Alternatively, clone the repo and copy the directories under `skills/` into your tool's skills directory.
 
 After installing, run the skill in your project:
 

--- a/src/components/reusable/AdsManagerSkill.mdx
+++ b/src/components/reusable/AdsManagerSkill.mdx
@@ -6,9 +6,9 @@ The [ads-manager skill](https://github.com/adaptyteam/adapty-sdk-integration-ski
 
 **Supported tools**: Claude Code, GitHub Copilot CLI, OpenAI Codex, Gemini CLI.
 
-The skill drives the Adapty CLI, so install and authenticate the CLI first — see the [quickstart guide](developer-cli-quickstart).
+The skill drives the Adapty CLI, so install and authenticate the CLI first — see the [quickstart guide](developer-cli-quickstart). The `adapty asa` commands ship in **Adapty CLI 0.4.0 and newer**; on an older version they do not exist at all. Check with `adapty asa whoami`, which also tells you whether an Apple Ads account is connected and whether the company has an active Ads Manager subscription.
 
-In a corporate Cowork workspace, an administrator must add `*.adapty.io` to the domain allowlist. Until they do, the skill cannot reach Adapty.
+In a corporate Cowork workspace, an administrator must add both `adapty.io` and `*.adapty.io` to the domain allowlist. List both: a wildcard does not cover the apex domain in most allowlist implementations, and the apex is where the documentation the skill reads lives. Until both are allowed, the skill cannot reach Adapty.
 
 To install, pick the form for your tool. The full list is in the [skill README](https://github.com/adaptyteam/adapty-sdk-integration-skill).
 
@@ -24,7 +24,8 @@ This plugin also contains the SDK integration skill. Both are installed together
 **GitHub Copilot CLI**
 
 ```bash
-gh skill install adaptyteam/adapty-sdk-integration-skill
+git clone https://github.com/adaptyteam/adapty-sdk-integration-skill.git
+cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/
 ```
 
 **Gemini CLI**
@@ -36,10 +37,12 @@ gemini skills install https://github.com/adaptyteam/adapty-sdk-integration-skill
 **OpenAI Codex or any other tool** — use the [skills CLI](https://skills.sh) (note that skills installed this way don't update automatically):
 
 ```bash
-npx skills add adaptyteam/adapty-sdk-integration-skill
+npx skills add adaptyteam/adapty-sdk-integration-skill --all
 ```
 
-Alternatively, clone the repo and copy `skills/ads-manager/` into your tool's skills directory.
+`--all` installs both skills into every agent it detects. For this skill on its own, use `--skill ads-manager`.
+
+Alternatively, clone the repo and copy the directories under `skills/` into your tool's skills directory — or just `skills/ads-manager/` if you only want this one.
 
 After installing, run the skill in your project:
 

--- a/src/data/agent-tools.json
+++ b/src/data/agent-tools.json
@@ -13,7 +13,8 @@
             "id": "copilot-cli",
             "label": "Copilot CLI",
             "commands": [
-                "gh skill install adaptyteam/adapty-sdk-integration-skill"
+                "git clone https://github.com/adaptyteam/adapty-sdk-integration-skill.git",
+                "cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/"
             ]
         },
         {
@@ -28,7 +29,7 @@
             "label": "Codex",
             "commands": [
                 "git clone https://github.com/adaptyteam/adapty-sdk-integration-skill.git",
-                "cp -r adapty-sdk-integration-skill/skills/adapty-sdk-integration ~/.agents/skills/"
+                "cp -r adapty-sdk-integration-skill/skills/* ~/.agents/skills/"
             ]
         },
         {
@@ -36,7 +37,7 @@
             "label": "Any tool",
             "note": "anyToolNote",
             "commands": [
-                "npx skills add adaptyteam/adapty-sdk-integration-skill"
+                "npx skills add adaptyteam/adapty-sdk-integration-skill --all"
             ]
         }
     ]


### PR DESCRIPTION
Since `ads-manager` landed in the skill repo, several of the install commands we publish deliver one skill, or none.

Three English files: the two reusable components and the agent-tools modal.

## Commands

| Tool | Before | Now |
|---|---|---|
| Claude Code | `claude plugin install ...` | **unchanged** — already installs both |
| Copilot CLI | `gh skill install ...` | clone + `cp -r skills/*` |
| Codex | `cp -r .../skills/adapty-sdk-integration` | `cp -r .../skills/*` |
| Any tool | `npx skills add <repo>` | `npx skills add <repo> --all` |
| Gemini CLI | unchanged | unchanged — see Not verified |

**`gh skill install` is not a real command.** `gh skill --help` → `unknown command "skill" for "gh"`. The Copilot instructions have therefore never worked; the clone-and-copy used elsewhere is the path that does. If a `gh` extension provides this verb, tell me and I'll restore it with the `gh extension install` step it needs.

**`npx skills add <repo>` now opens a picker**, because the CLI finds two skills — verified with `--list`, which prints "Found 2 skills" and ends with `Use --skill <name> to install specific skills`. `--all` is documented as shorthand for `--skill '*' --agent '*' -y`, which would be redundant if the bare form already installed everything. Fine interactively, hangs in a script.

**The manual copies were the quiet bug.** `cp -r .../skills/adapty-sdk-integration` names one directory, so a reader got the SDK skill and silently no `ads-manager`. `skills/*` takes both and survives a third.

**Claude Code needed no change** — `.claude-plugin/plugin.json` doesn't enumerate skills, so both are auto-discovered. The SDK component now says so, since the plugin is named for one skill and carries two.

## Two corrections on the ads-manager page

**The Cowork allowlist needs the apex too.** It said `*.adapty.io` alone. A wildcard doesn't match the apex in most implementations, and the apex is where the documentation the skill reads lives — 281 of the skill's URLs are `adapty.io/...` against 12 on `app.adapty.io`. Allowing only the wildcard leaves the dashboard and API reachable and blocks every docs fetch, which looks like the skill misbehaving rather than the network refusing. Now names both.

**Named the CLI floor.** `adapty asa` ships in Adapty CLI **0.4.0** and does not exist before it — on 0.3.0 you get `Command asa not found`, with nothing pointing at the cause. Also points at `adapty asa whoami`, which reports Apple connection and Ads Manager subscription state in one call.

## Localization

`src/locales/*/reusable/` holds 7 translated copies of each component, and they currently carry the broken `gh skill install`, the un-flagged `npx skills add`, and the `*.adapty.io`-only allowlist. **I have not hand-edited them.** `translate.yml` fires on push to `main` with `src/components/reusable/**` among its paths, so the 14 copies regenerate from the new English source after merge. Editing them directly would be overwritten and would desync the `.hashes` entries.

`src/data/agent-tools.json` needs no translation — the commands are language-neutral, and its `anyToolNote` text lives in `src/locales/ui-strings.ts`, which I did not need to touch.

## Not verified

`gemini skills install <url>` is left alone: `gemini` isn't installed on this machine, so I couldn't check how it handles a two-skill repo. If it behaves like the skills CLI, it needs a flag too.

Matching PR on the skill repo: adaptyteam/adapty-sdk-integration-skill#29.
