### PR TITLE
Move the Cowork section to the end of the CLI quickstart

### DIFF
--- a/src/content/docs/developer-cli/developer-cli-quickstart.mdx
+++ b/src/content/docs/developer-cli/developer-cli-quickstart.mdx
@@ -16,31 +16,7 @@ Connecting Adapty to App Store Connect and Google Play still requires a one-time
 
 By the end, your app, access level, product, paywall, and placement are all visible in the [Adapty dashboard](https://app.adapty.io).
 
-## Run the CLI in Cowork
-
-Claude Cowork runs commands in a sandbox that reaches only allowlisted domains. Until you allow Adapty, the CLI can't sign in or read your account. Skip this section if you run the CLI from your own terminal.
-
-Allow both `adapty.io` and `*.adapty.io`. A wildcard doesn't cover the apex domain in most allowlist implementations. The CLI itself reaches `api.adapty.io`, and an agent that reads the Adapty documentation while it works reaches the apex.
-
-Cowork applies these settings when a task starts. If you change the access mode or add a domain during a conversation, that conversation keeps the settings it started with — start a new task.
-
-### Personal accounts
-
-You set the allowlist yourself:
-
-1. In Claude, open **Settings** → **Capabilities**.
-2. Turn on **Code execution and file creation**. The **Allow network egress** block stays hidden until you do.
-3. Turn on **Allow network egress**.
-4. In **Domain allowlist**, select **Package managers only**.
-5. Under **Additional allowed domains**, add `adapty.io`, then add `*.adapty.io`.
-
-<ZoomImage id="cowork-network-egress.png" width="700px" alt="Allow network egress settings in Claude, with the Adapty domain in the additional allowed domains list" />
-
-The other access mode, **All domains**, lets the sandbox reach any site. With that selected, you don't add the Adapty domains at all.
-
-### Corporate workspaces
-
-An administrator controls the allowlist. Ask them to add both domains for the workspace.
+If you run the CLI in Claude Cowork, allow the Adapty domains before you start — see [Run the CLI in Cowork](#run-the-cli-in-cowork).
 
 ## 1. Install the CLI
 
@@ -184,6 +160,32 @@ adapty placements create --app <app-id> --title "Main" --developer-id "main" --a
 ```
 
 The `--audiences` flag controls which paywall is shown to which users. The example above sets a single default audience — every user at this placement sees the same paywall.
+
+## Run the CLI in Cowork
+
+Claude Cowork runs commands in a sandbox that reaches only allowlisted domains. Until you allow Adapty, the CLI can't sign in or read your account. Skip this section if you run the CLI from your own terminal.
+
+Allow both `adapty.io` and `*.adapty.io`. A wildcard doesn't cover the apex domain in most allowlist implementations. The CLI itself reaches `api.adapty.io`, and an agent that reads the Adapty documentation while it works reaches the apex.
+
+Cowork applies these settings when a task starts. If you change the access mode or add a domain during a conversation, that conversation keeps the settings it started with — start a new task.
+
+### Personal accounts
+
+You set the allowlist yourself:
+
+1. In Claude, open **Settings** → **Capabilities**.
+2. Turn on **Code execution and file creation**. The **Allow network egress** block stays hidden until you do.
+3. Turn on **Allow network egress**.
+4. In **Domain allowlist**, select **Package managers only**.
+5. Under **Additional allowed domains**, add `adapty.io`, then add `*.adapty.io`.
+
+<ZoomImage id="cowork-network-egress.png" width="700px" alt="Allow network egress settings in Claude, with the Adapty domain in the additional allowed domains list" />
+
+The other access mode, **All domains**, lets the sandbox reach any site. With that selected, you don't add the Adapty domains at all.
+
+### Corporate workspaces
+
+An administrator controls the allowlist. Ask them to add both domains for the workspace.
 
 ## What's next
 


### PR DESCRIPTION
Follow-up to #484.

Putting `## Run the CLI in Cowork` ahead of step 1 pushed the actual quickstart below the fold for the majority of readers, who run the CLI from a normal terminal and don't need it at all.

The section moves to just before `## What's next`, unchanged. A single sentence after the intro points to its anchor, so readers who do need it first still find it before they hit the install and auth steps that fail without the allowlist:

> If you run the CLI in Claude Cowork, allow the Adapty domains before you start — see [Run the CLI in Cowork](#run-the-cli-in-cowork).

The cross-article link from the `AdsManagerSkill` snippet targets the same anchor and still resolves.

`check-mdx-parse`, `lint-mdx`, and `check-links-diff` pass — 0 broken, 0 stale, 0 missing anchors.
