### PR TITLE
docs: highlight that Adapty Attribution is opt-in in iOS 4.1 migration guide

### DIFF
--- a/src/content/docs/ios/migration-to-ios-sdk-41.mdx
+++ b/src/content/docs/ios/migration-to-ios-sdk-41.mdx
@@ -23,7 +23,11 @@ The renamed APIs are a hard break. The old names are removed outright — they a
 | Fallback file downloaded for 4.0 | New fallback file format; download the file again |
 | Promoted in-app purchases not supported | `didReceivePromotedPurchase(_:)` delegate method and `AdaptyPromotedProduct` |
 
-## Adapty Attribution is disabled by default
+## ⚠️ Adapty Attribution is disabled by default \{#adapty-attribution-is-disabled-by-default\}
+
+:::warning
+If you update to SDK 4.1 and don't opt in, [Adapty Attribution](user-acquisition) breaks silently — installs stop registering, and nothing warns you.
+:::
 
 In 4.0 and earlier, the SDK registered installs for [Adapty Attribution](user-acquisition) automatically. Starting from 4.1, this is off by default: the SDK doesn't register installs, and the `onInstallationDetailsSuccess` and `onInstallationDetailsFail` delegate callbacks never fire. `getCurrentInstallationStatus()` returns `.notAvailable`.
 


### PR DESCRIPTION
## Summary

Per [Slack feedback](https://adapty-team.slack.com/archives/C06R77S3LDA/p1786621865590099), the "Adapty Attribution is disabled by default" section in the iOS 4.1 migration guide was too easy to skim past.

- Add ⚠️ to the section title, with an explicit heading id so the existing `#adapty-attribution-is-disabled-by-default` anchor keeps working
- Add a warning callout right under the heading: attribution breaks silently if you update without opting in

## Verification

`check-mdx-parse` and `lint-mdx` pass.