### PR TITLE
docs: move the Expo buildReactNativeFromSource requirement to troubleshooting

### DIFF
--- a/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
+++ b/src/content/docs/react-native/migration-to-react-native-sdk-v4.mdx
@@ -59,8 +59,7 @@ Add the [`expo-build-properties`](https://docs.expo.dev/versions/latest/sdk/buil
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "dynamic",
-            "buildReactNativeFromSource": true
+            "useFrameworks": "dynamic"
           }
         }
       ]
@@ -69,14 +68,14 @@ Add the [`expo-build-properties`](https://docs.expo.dev/versions/latest/sdk/buil
 }
 ```
 
-`buildReactNativeFromSource` is required on **Expo SDK 57 and later**. Expo SDK 57 ships a prebuilt React Native framework whose headers other packages can't reach once frameworks are dynamic, so the iOS build fails with errors like `'React/RCTBridge.h' file not found` in `expo-updates` or `@expo/ui`. Building React Native from source avoids the conflict, at the cost of longer iOS builds. On Expo SDK 56 and earlier, you can omit this option.
-
 Then install the plugin and regenerate the native project:
 
 ```bash showLineNumbers
 npx expo install expo-build-properties
 npx expo prebuild --clean
 ```
+
+If the iOS build then fails with `'React/RCTBridge.h' file not found`, update `expo-modules-autolinking` to 57.0.10 or later (Expo SDK 57) or 56.0.22 or later (Expo SDK 56) — see [the troubleshooting entry](sdk-installation-react-native-expo#react-header-not-found) for details and a workaround.
 
 #### Bare React Native
 

--- a/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
@@ -114,8 +114,7 @@ v4 pulls the native iOS SDKs (`Adapty`, `AdaptyUI`, `AdaptyPlugin`) through Swif
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "dynamic",
-            "buildReactNativeFromSource": true
+            "useFrameworks": "dynamic"
           }
         }
       ]
@@ -124,14 +123,14 @@ v4 pulls the native iOS SDKs (`Adapty`, `AdaptyUI`, `AdaptyPlugin`) through Swif
 }
 ```
 
-`buildReactNativeFromSource` is required on **Expo SDK 57 and later**. Expo SDK 57 ships a prebuilt React Native framework whose headers other packages can't reach once frameworks are dynamic, so the iOS build fails with errors like `'React/RCTBridge.h' file not found` in `expo-updates` or `@expo/ui`. Building React Native from source avoids the conflict, at the cost of longer iOS builds. On Expo SDK 56 and earlier, you can omit this option.
-
 Then install the plugin and regenerate the native project:
 
 ```sh
 npx expo install expo-build-properties
 npx expo prebuild --clean
 ```
+
+If the iOS build then fails with `'React/RCTBridge.h' file not found`, see [the troubleshooting entry](#react-header-not-found).
 
 See [Migrate Adapty React Native SDK to v4](migration-to-react-native-sdk-v4) for the full migration.
 
@@ -436,3 +435,40 @@ Include `"configureAndroidBackup": false` if you use `expo-secure-store` to prev
 This setup only respects backup requirements for Adapty, AppsFlyer, and expo-secure-store.
 If other libraries in your project define custom backup rules, you’ll need to configure those manually.
 :::
+
+#### iOS build fails with `'React/RCTBridge.h' file not found` \{#react-header-not-found\}
+
+With [dynamic frameworks enabled for Adapty SDK 4.0](#adapty-sdk-40-enable-swift-package-manager), the iOS build may fail in `expo-updates`, `@expo/ui`, or another package with Objective-C sources:
+
+```
+error: 'React/RCTBridge.h' file not found
+```
+
+The failure is caused by a bug in the `expo-modules-autolinking` package (an `expo` dependency). Affected versions are 57.0.5–57.0.9 (Expo SDK 57) and 56.0.19–56.0.21 (Expo SDK 56); the bug is fixed in 57.0.10 and 56.0.22.
+
+To fix the build, update `expo-modules-autolinking` to the fixed version and regenerate the native project:
+
+```sh
+npm update expo-modules-autolinking
+npx expo prebuild --clean
+```
+
+If the fixed version isn't available for your Expo SDK yet, build React Native from source instead. It works around the bug at the cost of longer iOS builds:
+
+```json title="app.json"
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "dynamic",
+            "buildReactNativeFromSource": true
+          }
+        }
+      ]
+    ]
+  }
+}
+```


### PR DESCRIPTION
## What

The Expo installation path for React Native SDK 4.0 no longer tells everyone on Expo SDK 57+ to set `"buildReactNativeFromSource": true`. The underlying build failure was a bug in `expo-modules-autolinking` (see [expo/expo#48781](https://github.com/expo/expo/issues/48781), reported via [AdaptySDK-React-Native#332](https://github.com/adaptyteam/AdaptySDK-React-Native/issues/332)), affecting versions 57.0.5–57.0.9 and 56.0.19–56.0.21, and fixed in 57.0.10 (published) and 56.0.22 (upcoming).

## Changes

- **sdk-installation-react-native-expo**: removed `buildReactNativeFromSource` from the SDK 4.0 `app.json` snippet and the paragraph requiring it. Added a troubleshooting entry — *iOS build fails with `'React/RCTBridge.h' file not found`* — naming the affected `expo-modules-autolinking` versions, the fix (update the package, re-run `expo prebuild --clean`), and `buildReactNativeFromSource: true` as the fallback for anyone who can't update yet (the SDK 56 fix isn't on npm yet).
- **migration-to-react-native-sdk-v4**: same snippet cleanup, with a one-line pointer to the troubleshooting entry.

## Verification

- `check-mdx-parse` and `lint-mdx` pass on both files.
- Affected/fixed version ranges confirmed against the npm registry (`57.0.10` published, latest 56.x is `56.0.21`).