### PR TITLE
docs: legacy builders keep editing after deprecation

### DIFF
--- a/src/content/docs/guides/flow-builder/paywall-onboarding-builder-deprecation.mdx
+++ b/src/content/docs/guides/flow-builder/paywall-onboarding-builder-deprecation.mdx
@@ -1,24 +1,24 @@
 ---
 title: "Paywall Builder and Onboarding Builder deprecation"
-description: "On October 1, 2026, the legacy Paywall Builder and Onboarding Builder become read-only. Published paywalls and onboardings keep working — build new ones in Flow Builder."
+description: "On October 1, 2026, Adapty deprecates the legacy Paywall Builder and Onboarding Builder. Published paywalls and onboardings keep working and stay editable — build new ones in Flow Builder."
 metadataTitle: "Paywall Builder and Onboarding Builder deprecation | Adapty Docs"
 ---
 
-On October 1, 2026, Adapty deprecates the legacy Paywall Builder and Onboarding Builder in favor of [Flow Builder](adapty-flow-builder). Everything you've published keeps working: your users keep seeing your paywalls and onboardings, and your data stays in place. The deprecation turns off editing in the legacy builders and ends support for them.
+On October 1, 2026, Adapty deprecates the legacy Paywall Builder and Onboarding Builder in favor of [Flow Builder](adapty-flow-builder). Everything you've published keeps working: your users keep seeing your paywalls and onboardings, and your data stays in place. You can still edit your existing paywalls and onboardings. The deprecation turns off creating new ones and ends support for the legacy builders.
 
 ## What keeps working
 
-The deprecation doesn't change anything for your users:
+The deprecation doesn't change anything for your users, and your existing paywalls and onboardings stay editable:
 
 - **Published paywalls and onboardings**: The Adapty SDK keeps rendering them in your apps, on the placements they're assigned to today.
+- **Editing**: You can still edit your existing paywalls and onboardings in the legacy builders.
 - **Your data**: Paywalls, onboardings, and their metrics stay in your dashboard. Nothing is deleted.
 
 ## What stops on October 1, 2026
 
-From that date, the legacy builders are read-only:
+From that date, in the legacy builders:
 
 - **No new paywalls or onboardings**: You can't create them in the legacy builders. Build new ones in [Flow Builder](adapty-flow-builder).
-- **No edits**: You can't change an existing paywall or onboarding. To change one, recreate it as a flow.
 - **No support**: Adapty no longer ships fixes for the legacy builders.
 
 ## Move to Flow Builder
@@ -29,6 +29,6 @@ A [flow](adapty-flow-builder) combines onboarding screens and a paywall into one
 A one-click migration that converts a legacy paywall into a flow is coming soon.
 :::
 
-Plan for an app release: flows render on Adapty SDK v4 and later, so users see your flow only after they update to an app version built with it. After October 1, any change to a legacy paywall or onboarding means recreating it as a flow. Start the SDK upgrade now, so a v4 release is already live when you need to make that change.
+Plan for an app release: flows render on Adapty SDK v4 and later, so users see your flow only after they update to an app version built with it. Start the SDK upgrade now, so a v4 release is already live when your first flow is ready.
 
 If a paywall drives most of your revenue and you don't want to switch all of its traffic at once, [roll the flow out gradually](flow-gradual-rollout): serve it to a small share of users alongside the existing paywall, compare conversion, and raise the share as the results hold up.


### PR DESCRIPTION
## What changed

Updated the [Paywall Builder and Onboarding Builder deprecation](https://adapty.io/docs/paywall-onboarding-builder-deprecation) article: after October 1, 2026, users can still edit their existing paywalls and onboardings in the legacy builders. The article previously said the builders become fully read-only.

- Intro, frontmatter description, and "What keeps working" now state that existing paywalls and onboardings stay editable.
- "What stops on October 1, 2026" is down to two items: no new paywalls or onboardings, and no support.
- Removed the "recreate it as a flow" requirement from the migration section, since edits no longer force a recreate.

## Verification

- `check-mdx-parse` and `lint-mdx` pass.