### PR TITLE
docs: mention landing pages alongside web funnels in the web pixel article

### DIFF
--- a/src/content/docs/version-3.0/ua-web-pixel.mdx
+++ b/src/content/docs/version-3.0/ua-web-pixel.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Set up the Adapty web pixel"
-description: "Install the Adapty web pixel on your web funnel so purchases made through Stripe or Paddle are attributed to the ads that drove them."
+description: "Install the Adapty web pixel on your web funnel or landing page so purchases made through Stripe or Paddle are attributed to the ads that drove them."
 metadataTitle: "Web pixel | Adapty Attribution | Adapty Docs"
 ---
 
-If you acquire users through a web funnel, the Adapty web pixel connects each funnel visit to the ad that brought it. The pixel assigns every visitor a click ID. When the visitor pays, you pass that click ID with the transaction, and Adapty Attribution matches the purchase to the exact campaign, ad set, and ad.
+If you acquire users through a web funnel or landing page, the Adapty web pixel connects each visit to the ad that brought it. The pixel assigns every visitor a click ID. When the visitor pays, you pass that click ID with the transaction, and Adapty Attribution matches the purchase to the exact campaign, ad set, and ad.
 
 The pixel is available for Meta Ads and TikTok for Business campaigns.
 


### PR DESCRIPTION
## What changed

In `ua-web-pixel.mdx`, the SEO description and the intro now say "web funnel or landing page" instead of just "web funnel", so readers acquiring users through a standalone landing page recognize the pixel applies to them too. The intro's "each funnel visit" became "each visit" to cover both cases.

The two **Web funnel** mentions in the install and ad-URL steps are untouched — they quote the section label in the campaign configuration UI.

## Verification

`check-mdx-parse` and `lint-mdx` pass.