### PR TITLE
docs: replace Timur's Calendly link with Murat's in attribution articles

### DIFF
--- a/src/content/docs/version-3.0/adapty-user-acquisition.mdx
+++ b/src/content/docs/version-3.0/adapty-user-acquisition.mdx
@@ -17,7 +17,7 @@ Adapty Attribution is an attribution solution that connects ad campaigns with ap
 - Analyze cohort performance and user behavior over time
 
 :::tip
-Want to learn more about the way Adapty Attribution might be useful to you? [Book a call](https://calendly.com/tnurutdinov-adapty/30min) with us.
+Want to learn more about the way Adapty Attribution might be useful to you? [Book a call](https://calendly.com/adapty-murat/meeting-1) with us.
 :::
 
 ## Why choose Adapty Attribution?

--- a/src/content/docs/version-3.0/meta-create-campaign.mdx
+++ b/src/content/docs/version-3.0/meta-create-campaign.mdx
@@ -151,4 +151,4 @@ To activate your ad, you will need to add a payment method if you haven't done i
 
 Then, you can [explore how the campaign affects your app revenue in the Adapty Attribution dashboard](adapty-user-acquisition).
 
-Not using Adapty Attribution yet? [Book a call with us](https://calendly.com/tnurutdinov-adapty/30min) to learn how it can help you track and optimize your ad campaigns.
+Not using Adapty Attribution yet? [Book a call with us](https://calendly.com/adapty-murat/meeting-1) to learn how it can help you track and optimize your ad campaigns.

--- a/src/content/docs/version-3.0/tiktok-create-campaign.mdx
+++ b/src/content/docs/version-3.0/tiktok-create-campaign.mdx
@@ -127,4 +127,4 @@ To start running the ad, after you configure targeting and ad budget, enter your
 
 Now, you can [explore how the campaign affects your app revenue in the Adapty Attribution dashboard](adapty-user-acquisition).
 
-Not using Adapty Attribution yet? [Book a call with us](https://calendly.com/tnurutdinov-adapty/30min) to learn how it can help you track and optimize your ad campaigns.
+Not using Adapty Attribution yet? [Book a call with us](https://calendly.com/adapty-murat/meeting-1) to learn how it can help you track and optimize your ad campaigns.


### PR DESCRIPTION
## What

Replaces the booking link `https://calendly.com/tnurutdinov-adapty/30min` with `https://calendly.com/adapty-murat/meeting-1` in the three articles that used it:

- `adapty-user-acquisition.mdx`
- `tiktok-create-campaign.mdx`
- `meta-create-campaign.mdx`

Locale copies and generated `static/` files are untouched — they pick up the change automatically via the translation workflow and the build.