### PR TITLE
docs: drop --clean from the Expo React header build fix

### DIFF
--- a/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
@@ -450,7 +450,7 @@ To fix the build, update `expo-modules-autolinking` to the fixed version and reg
 
 ```sh
 npm update expo-modules-autolinking
-npx expo prebuild --clean
+npx expo prebuild
 ```
 
 If the fixed version isn't available for your Expo SDK yet, build React Native from source instead. It works around the bug at the cost of longer iOS builds:


### PR DESCRIPTION
Drops `--clean` from the `expo prebuild` command in the **iOS build fails with `'React/RCTBridge.h' file not found`** troubleshooting entry of the Expo installation guide.

Updating `expo-modules-autolinking` and re-running prebuild is enough to pick up the fixed autolinking; wiping the native directories isn't needed, and `--clean` costs the reader a full rebuild from scratch.

The lead-in sentence ("regenerate the native project") is accurate for a plain prebuild, so no prose change was needed.

### Deliberately unchanged

The other two `expo prebuild --clean` calls in the same article are left as they are — this change is scoped to the one troubleshooting entry:

- the SPM setup step under *Adapty SDK 4.0: enable Swift Package Manager*
- the *Minimum iOS version error* troubleshooting entry

### Verification

- `node scripts/check-mdx-parse.mjs` — 5929 files parsed cleanly
- `node scripts/lint-mdx.mjs` on the edited file — OK
