### PR TITLE
Add a Cmd+K hint to the docs search field

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -45,7 +45,7 @@ const indexName =
       autocorrect="off"
       autocapitalize="off"
       spellcheck="false"
-      class="block w-full pl-10 pr-3 py-2 bg-slate-50 border border-slate-200 rounded-xl text-[14px] placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/10 focus:border-[var(--accent-primary)] focus:bg-white transition-all font-medium text-slate-900"
+      class="block w-full pl-10 pr-16 py-2 bg-slate-50 border border-slate-200 rounded-xl text-[14px] placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]/10 focus:border-[var(--accent-primary)] focus:bg-white transition-all font-medium text-slate-900"
       data-app-id={import.meta.env.PUBLIC_ALGOLIA_APP_ID || ''}
       data-api-key={import.meta.env.PUBLIC_ALGOLIA_SEARCH_KEY || ''}
       data-index-name={indexName}
@@ -59,6 +59,16 @@ const indexName =
       data-index-name-fr={import.meta.env.PUBLIC_ALGOLIA_INDEX_NAME_FR ?? ''}
       data-analytics-key={import.meta.env.PUBLIC_ALGOLIA_ANALYTICS_KEY || ''}
     />
+    <!-- Shortcut hint — hidden once the field has text (see :placeholder-shown rule below) -->
+    <kbd id="search-kbd" aria-hidden="true">⌘K</kbd>
+    <script is:inline>
+      // Swap the hint to Ctrl K off macOS. Inline so it resolves during parse, before first paint.
+      (() => {
+        const kbd = document.getElementById('search-kbd');
+        const platform = navigator.userAgentData?.platform || navigator.platform || '';
+        if (kbd && !/mac/i.test(platform)) kbd.textContent = 'Ctrl K';
+      })();
+    </script>
   </div>
 
   <!-- Search Results Dropdown -->
@@ -93,6 +103,35 @@ const indexName =
     border-color: var(--accent-primary) !important;
   }
   
+  #search-kbd {
+    position: absolute;
+    top: 50%;
+    right: 0.5rem;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.625rem;
+    padding: 0.125rem 0.375rem;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 0.5rem;
+    color: var(--text-tertiary);
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.45;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+  }
+
+  /* :placeholder-shown is true only while the field is empty */
+  #search-input:not(:placeholder-shown) ~ #search-kbd {
+    opacity: 0;
+  }
+
   #search-results {
     background: var(--bg-primary);
     border-color: var(--border-primary);

--- a/src/locales/ui-strings.ts
+++ b/src/locales/ui-strings.ts
@@ -21,7 +21,7 @@ export const UI_STRINGS = {
     signUpFree:    { en: 'Sign Up for Free', zh: '免费注册',   tr: 'Ücretsiz Kaydol',   ru: 'Зарегистрироваться',       es: 'Registrarse gratis', ja: '無料で登録', vi: 'Đăng ký miễn phí', fr: 'S\'inscrire gratuitement' },
   },
   search: {
-    placeholder: { en: 'Search documentation...', zh: '搜索文档...',       tr: 'Dokümantasyonda ara...',  ru: 'Поиск...',                es: 'Buscar en la documentación...', ja: 'ドキュメントを検索...', vi: 'Tìm trong tài liệu...', fr: 'Rechercher dans la documentation...' },
+    placeholder: { en: 'Search docs...',          zh: '搜索文档...',       tr: 'Dokümanlarda ara...',     ru: 'Поиск...',                es: 'Buscar en los docs...',         ja: 'ドキュメントを検索...', vi: 'Tìm trong tài liệu...', fr: 'Rechercher dans les docs...' },
     noResults:   { en: 'No results found.',        zh: '未找到相关结果。', tr: 'Sonuç bulunamadı.',       ru: 'Результаты не найдены.', es: 'No se han encontrado resultados.', ja: '結果が見つかりませんでした。', vi: 'Không tìm thấy kết quả.', fr: 'Aucun résultat trouvé.' },
   },
   articleButtons: {

--- a/src/scripts/search.ts
+++ b/src/scripts/search.ts
@@ -27,12 +27,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!searchInput || !searchResults || !searchContainer) return;
 
+    // An element rendered but hidden (e.g. Tailwind `hidden xl:flex`) has no boxes.
+    const isVisible = (el: HTMLElement) =>
+        !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+
     // Cmd+K / Ctrl+K keyboard shortcut to focus search
     document.addEventListener('keydown', (e) => {
         // Check for Cmd+K (Mac) or Ctrl+K (Windows/Linux)
         if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
             e.preventDefault();
-            searchInput.focus();
+
+            if (isVisible(searchInput)) {
+                searchInput.focus();
+                return;
+            }
+
+            // Below xl the header field is hidden and search lives in the overlay.
+            // Click the trigger that's actually on screen so the overlay's own
+            // open handler (DocsLayout.astro) stays the single source of truth.
+            const trigger = Array.from(
+                document.querySelectorAll<HTMLElement>('[data-search-trigger]')
+            ).find(isVisible);
+            trigger?.click();
         }
     });
 


### PR DESCRIPTION
The docs search has had a Cmd+K binding for a while, but nothing advertised it. This adds the usual badge inside the field.

## What changed

**A shortcut badge in the header search field.** Renders `⌘K`, swapped to `Ctrl K` off macOS by a small inline script so it resolves during parse — no flash of the wrong glyph. It fades out once the field has text and comes back when cleared, which is pure CSS (`:not(:placeholder-shown)`), so no extra JS listener and nothing to keep in sync with the existing Algolia input handler.

The badge is on the header field only. Below `xl` that field is hidden and search runs through the mobile overlay, whose trigger is a 20px icon with no room for a badge.

**Cmd+K now works in the 1024–1280px band.** It previously called `.focus()` on the header input, which in that band is in the DOM but hidden — so the shortcut silently did nothing. It now clicks whichever `[data-search-trigger]` is actually on screen, which keeps `DocsLayout`'s delegated handler as the single place that knows how to open the overlay (focus timing, body scroll-lock, and Escape-to-close all come along unchanged).

Visibility is a box test rather than a hardcoded breakpoint, so it reads the same `hidden xl:flex` classes the layout already uses and won't drift if the breakpoint moves.

**Placeholder shortened** from "Search documentation..." to "Search docs...". I shortened `tr`, `es`, and `fr` to match; `zh`, `ja`, `vi`, and `ru` were already short. Those three could use a native-speaker glance.

## Verified

Dev server, both themes:

| Viewport | Visible trigger | Cmd+K result |
|---|---|---|
| 1440px | header field | focuses the header input (unchanged) |
| 1100px | compact icon button | overlay opens, focus moves to its input |
| 375px | mobile icon button | overlay opens, focus moves to its input |

Also checked: badge hides on typing and returns on clear; `Ctrl K` measures 44px and still fits inside the field's 64px right padding, so it can't collide with typed text; Escape closes the overlay and restores body scroll; repeat presses are idempotent; no console errors.