### PR TITLE
docs: country code format and Cloudflare DNS-only requirement

### DIFF
--- a/src/api-reference/specs/adapty-api.yaml
+++ b/src/api-reference/specs/adapty-api.yaml
@@ -1672,7 +1672,7 @@ components:
         ip_country:
           type: string
           nullable: true
-          description: Country of the end user in ISO 3166-2 format
+          description: Country of the end user as a two-letter ISO 3166-1 alpha-2 code, for example `FR`
         ip_v4_address:
           type: string
           nullable: true
@@ -1680,7 +1680,7 @@ components:
         store_country:
           type: string
           nullable: true
-          description: Country of the end user's app store
+          description: Country of the end user's app store as a two-letter ISO 3166-1 alpha-2 code, for example `US`
         store:
           type: string
           nullable: true
@@ -2246,10 +2246,10 @@ components:
       properties:
         country:
           type: string
-          description: Country code
+          description: Country code in ISO 3166-1 alpha-2 format, for example `US`
         currency:
           type: string
-          description: Currency code
+          description: Currency code in ISO 4217 format, for example `USD`
         value:
           type: number
           format: float

--- a/src/api-reference/specs/adapty-mail-api.yaml
+++ b/src/api-reference/specs/adapty-mail-api.yaml
@@ -300,10 +300,10 @@ components:
           description: The user's date of birth, in ISO 8601 format (for example, `"1990-05-21"`).
         country:
           type: string
-          description: The user's country as a two-letter uppercase ISO 3166-1 alpha-2 code (for example, `US`).
+          description: The user's country as a two-letter ISO 3166-1 alpha-2 code (for example, `US`).
         store_country:
           type: string
-          description: The user's store region as a two-letter uppercase ISO 3166-1 alpha-2 code (for example, `US`).
+          description: The user's store region as a two-letter ISO 3166-1 alpha-2 code (for example, `US`).
         custom_attributes:
           type: object
           description: |

--- a/src/content/docs/version-3.0/mail-send-data-via-api.mdx
+++ b/src/content/docs/version-3.0/mail-send-data-via-api.mdx
@@ -61,6 +61,10 @@ curl --request POST \
   }'
 ```
 
+:::note
+`country` and `store_country` take a two-letter [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code — `US`, not `USA` or `United States`. Any other value is rejected.
+:::
+
 See the [Save profile](api-mail/operations/saveProfile) reference for every available field.
 
 ## Send transaction events

--- a/src/content/docs/version-3.0/mail-sending-domain.mdx
+++ b/src/content/docs/version-3.0/mail-sending-domain.mdx
@@ -32,6 +32,10 @@ Domain setup lives in **Settings → DNS**, in the **Email domains** section.
 
    <ZoomImage id="email-domains.webp" width="700px" alt="Expanded domain card showing DNS record groups and verification progress" />
 
+:::warning
+**On Cloudflare, every CNAME must be DNS only.** Cloudflare proxies new records by default, so a CNAME you add by hand ends up **Proxied** (the orange cloud) and resolves to Cloudflare's own address instead of the target Adapty Mail issued — it never verifies. Click the cloud to switch each CNAME to **DNS only**. The **Cloudflare zone file** export sets DNS only for you, so imported records need no change.
+:::
+
 The counter and ring in the card header track how many required records have verified, so they fill only once every one of them resolves.
 
 ### Choosing the sending subdomain
@@ -191,6 +195,7 @@ When an email is due, Adapty Mail tries the project's domains in order and sends
 | "This subdomain cannot be used"                                                | The label is reserved or was rejected by screening. Pick another one — see [Choosing the sending subdomain](#choosing-the-sending-subdomain). |
 | "Please wait before checking again"                                            | Wait 10 seconds between manual checks. Automatic polling continues in the background.                                      |
 | Records stay unverified                                                        | Check that they match exactly — no trailing dots, correct CNAME targets, one value per record. DNS can take up to 48 hours to propagate. |
+| CNAMEs stay unverified on Cloudflare                                           | The records are **Proxied**. Switch each one to **DNS only**, then click **Check**.                                        |
 | Warm-up reads "Awaiting DNS record verification"                               | The warm-up mailbox's MX, DKIM, and SPF records aren't verified yet. Add or correct them, then click **Check**.             |
 | The `go.` group won't turn green                                               | The card shows the reason under the host. Confirm its CNAME and TXT records, then click **Check** — the domain isn't fully set up until this host is active. |
 | "Cannot delete: some identities are verified"                                  | The domain was set up before automatic warm-up and can't be removed from the dashboard. Contact support.                    |


### PR DESCRIPTION
Two pieces of user feedback on the Adapty Mail docs, plus a factual error found while verifying the first one.

## Adapty Mail

**Country codes.** `mail-send-data-via-api` now states that `country` and `store_country` take an ISO 3166-1 alpha-2 code (`US`, not `USA` or `United States`), and that anything else is rejected. This is the only Mail surface where a person types a country code — Segments renders a dropdown of country names, and Profiles is display-only.

**Cloudflare DNS only.** `mail-sending-domain` now warns that every CNAME must be **DNS only**. Cloudflare proxies new records by default, so a CNAME added by hand lands as **Proxied** and resolves to Cloudflare's own address instead of the issued target, and never verifies. The Cloudflare zone file export already tags every CNAME as not-proxied, which is why importing works and hand-entry doesn't. Added a matching troubleshooting row.

## Server-side API spec

Verifying the country-code claim turned up a real error and two gaps in `adapty-api.yaml`:

- `ip_country` described as **"ISO 3166-2 format"** — that's the subdivision standard (`US-CA`). The field is alpha-2. This string was authored in the docs, not inherited from the backend, and has been wrong since the January migration commit. Note `server-side-api-specs-legacy.mdx` has always described it correctly, so the docs contradicted themselves.
- `store_country` and `PriceDTO.country` documented no format at all.
- `PriceDTO.currency` likewise — now states ISO 4217.

## Adapty Mail API spec

Dropped "uppercase" from the two country field descriptions. The validator uppercases its input before checking, so lowercase is accepted and normalized; "uppercase" implied a strictness that isn't there.

Worth knowing that the two APIs genuinely differ here: Adapty Mail rejects `USA` outright, while the server-side API converts alpha-3 to alpha-2 and silently drops an unrecognized code. That difference is why the "is rejected" wording appears only in the Mail guide.

## Notes

- Every claim was verified against the backend and dashboard source rather than inferred from the existing docs.
- English specs only — the translated copies regenerate automatically on merge.
- Verified: both YAML specs parse, `check-mdx-parse` and `lint-mdx` clean, `check-links` clean for the new link (the 30 broken external links it reports are all pre-existing).