### PR TITLE
docs: process user input from flows (all 7 SDK platforms)

### DIFF
--- a/src/components/reusable/FlowInputLimitations.mdx
+++ b/src/components/reusable/FlowInputLimitations.mdx
@@ -1,0 +1,15 @@
+---
+no_index: true
+---
+
+import Callout from '../Callout.astro';
+
+:::warning
+Flows send raw values — email addresses, phone numbers, and whatever else a user types. Treat everything the analytics callback delivers as personal data, and don't write it anywhere you wouldn't write a user's email address.
+:::
+
+- **Last value wins**: You get one event per field, carrying the value the user settled on rather than a keystroke-by-keystroke stream. If they edit a field, only the last version reaches you.
+- **No submit guarantee**: Values reach you as users move through the flow, and a user can leave at any point. Wait for the flow to close before treating a set of answers as complete.
+- **Best-effort delivery**: The SDK sends text values when the field loses focus, and picker values when the picker closes. If a user closes the flow or backgrounds the app while a field is still focused or a picker is still open, that value can be lost.
+
+To make the last field's value reliable, end the flow with a screen that has no inputs and no pickers, and close the flow from an explicit user action rather than automatically when that screen appears. Moving to the final screen takes focus off the previous field, which is what sends its value.

--- a/src/components/reusable/FlowInputValueTypes.mdx
+++ b/src/components/reusable/FlowInputValueTypes.mdx
@@ -1,0 +1,23 @@
+---
+no_index: true
+---
+
+import Callout from '../Callout.astro';
+
+| `element_type`                                              | What `value` holds                                                                                                                       | When the event is sent                                    |
+|:------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------|
+| `text_input`, `email_input`, `number_input`, `phone_input` | The raw string the user typed. Numbers arrive as strings, not as numeric types.                                                          | When the field loses focus.                               |
+| `date_picker`, `time_picker`, `date_time_picker`           | Unix time in milliseconds.                                                                                                               | When the user closes a picker whose value they changed.   |
+| `single_choice`                                              | An object with `id` and `title`. `title` is `null` when the option has no text to take it from.                                          | After each tap.                                           |
+| `multi_choice`                                               | An array of `{ id, title }` objects — every option selected at that moment, in the order they appear in the builder.                     | After each tap.                                           |
+| `toggle`                                                     | A boolean.                                                                                                                               | After each tap.                                           |
+
+`element_id` is the **Element ID** you set on the input in the [Flow Builder](builder-inputs-and-forms). For `single_choice`, `multi_choice`, and `toggle`, it is the ID of the [selectable group](flow-selectable-elements) instead, and each option's `id` is that option's own **Element ID**.
+
+Branch on `id`, not on `title`. An option's `id` is the one you set in the builder, while its `title` is derived from the option's text and can come from your default locale rather than the language the user is reading, so it doesn't always match what they saw on screen.
+
+An email address is sent even when it fails the builder's format validation, so validate it again before you use it.
+
+:::note
+Password fields, file uploads, product selections, tab switches, and inputs placed inside a reusable component don't send events. Neither does a selection your flow makes on the user's behalf — only a tap counts. A selectable group whose options have duplicate or missing Element IDs sends nothing at all, rather than sending part of the answer.
+:::

--- a/src/content/docs/android/android-flow-input.mdx
+++ b/src/content/docs/android/android-flow-input.mdx
@@ -1,0 +1,283 @@
+---
+title: "Process data from flows in Android SDK"
+description: "Save and use data your users enter in flows in your Android app with Adapty SDK."
+metadataTitle: "Process data from flows | Android SDK | Adapty Docs"
+---
+
+When a user types into an input field, answers a quiz, or flips a toggle in a [flow](adapty-flow-builder), the SDK passes the value to your app through its analytics callback.
+
+Apps most often use that data to:
+
+- **Register users on their own backend**: Take the email address and the name a user entered in your onboarding flow, and create their account without a second sign-up screen.
+- **Save answers and preferences**: Keep what a user picked so your app can act on it later, or [write it to their Adapty profile](android-setting-user-attributes) as custom attributes.
+- **Customize the flows a user sees later**: Save quiz answers as custom attributes, then target a later placement so each segment gets a different flow, or a different paywall inside it.
+- **Feed your own analytics**: Forward answers to Amplitude, Mixpanel, or whichever product analytics you run.
+
+You don't set anything up in the builder — inputs and selectable groups report their values automatically.
+
+## Before you start
+
+You need:
+
+- **Adapty Android SDK v4 or later**: The flow callbacks don't exist in earlier versions.
+- **A flow built in the [Flow Builder](adapty-flow-builder)**: Only flows report input values through this callback.
+- **A recently published flow version**: A flow reports input values only if you published it after this feature became available. If nothing reaches your callback, publish a new version of the flow and try again.
+
+## Receive input values
+
+Input values reach the same callback as every other analytics event from a flow, under the event name `flow_user_input`. Override `onAnalyticEvent` on your flow event listener:
+
+```kotlin showLineNumbers title="Kotlin"
+class MyFlowEventListener : AdaptyFlowDefaultEventListener() {
+
+    override fun onAnalyticEvent(
+        name: String,
+        params: Map<String, Any?>,
+        context: Context,
+    ) {
+        handleFlowInput(name, params)
+    }
+}
+```
+
+A flow reports other analytics events through this callback as well, such as screen views. Match on `name` before you read anything else, or your handler will run on events that carry no input. See [Handle flow & paywall events](android-handling-events) for the rest of them.
+
+`params["payload"]` is a JSON **string**, not a map — decode it before you read the answer:
+
+```kotlin showLineNumbers title="Kotlin"
+private fun handleFlowInput(name: String, params: Map<String, Any?>) {
+    if (name != "flow_user_input") return
+
+    val payload = params["payload"] as? String ?: return
+    val input = JSONObject(payload)
+    val elementId = input.optString("element_id")
+
+    // The screen the input sits on. Pair it with elementId to tell apart
+    // two fields that share an Element ID on different screens.
+    val screenId = params["instanceId"] as? String
+
+    when (input.optString("element_type")) {
+        "text_input", "email_input", "number_input", "phone_input" -> {
+            val text = input.optString("value")
+        }
+        "date_picker", "time_picker", "date_time_picker" -> {
+            val millis = input.optLong("value")
+        }
+        "single_choice" -> {
+            val option = input.optJSONObject("value")
+        }
+        "multi_choice" -> {
+            val options = input.optJSONArray("value")
+        }
+        "toggle" -> {
+            val isOn = input.optBoolean("value")
+        }
+    }
+}
+```
+
+## What arrives in the callback
+
+| Parameter                  | Description                                                                                                                                                              |
+|:---------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                     | The event name. Input values reach you as `flow_user_input`.                                                                                                             |
+| `params["instanceId"]`     | The ID of the screen the input is on. An Element ID is unique within one screen but can repeat across screens, so use `instanceId` together with `element_id` to tell two fields apart. |
+| `params["payload"]`        | A JSON string holding the answer. Decode it to read `element_id`, `element_type`, and `value`.                                                                           |
+| `params["isCustomerEvent"]` | `true` for events meant for your own analytics.                                                                                                                          |
+| `params["isBackendEvent"]` | `false` for `flow_user_input`. Adapty doesn't receive or store what users enter — these values reach your app and nowhere else.                                          |
+
+The decoded `payload` holds:
+
+| Field          | Description                                                                                                     |
+|:---------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`      | The format version of the payload, currently `1`. Compare it against `1` before decoding to guard against later changes. |
+| `element_id`   | The **Element ID** of the input or selectable group the value came from.                                        |
+| `element_type` | The type of element that sent the value. It tells you how to read `value`.                                      |
+| `value`        | What the user entered or selected. Its shape depends on `element_type`.                                         |
+
+<FlowInputValueTypes />
+
+## Event examples
+
+These examples show the properties available on each event, with illustrative values in comments.
+
+<Details>
+<summary>Text, email, number, and phone input (Click to expand)</summary>
+
+```kotlin
+override fun onAnalyticEvent(name: String, params: Map<String, Any?>, context: Context) {
+    name                        // "flow_user_input"
+    params["instanceId"]        // "scr_J260KU5q"
+    params["isCustomerEvent"]   // true
+    params["isBackendEvent"]    // false
+    params["payload"]           // "{\"version\":1,\"element_id\":\"email\",\"element_type\":\"email_input\",\"value\":\"jane@example.com\"}"
+
+    // payload, once decoded:
+    input.optInt("version")             // 1
+    input.optString("element_id")       // "email"
+    input.optString("element_type")     // "email_input"
+    input.optString("value")            // "jane@example.com"
+}
+```
+</Details>
+
+<Details>
+<summary>Date, time, and date-time pickers (Click to expand)</summary>
+
+```kotlin
+override fun onAnalyticEvent(name: String, params: Map<String, Any?>, context: Context) {
+    // payload, once decoded:
+    input.optString("element_id")    // "birthday"
+    input.optString("element_type")  // "date_picker"
+    input.optLong("value")           // 645408000000   (Unix milliseconds — 1990-06-15)
+}
+```
+</Details>
+
+<Details>
+<summary>Single choice (Click to expand)</summary>
+
+```kotlin
+override fun onAnalyticEvent(name: String, params: Map<String, Any?>, context: Context) {
+    // payload, once decoded:
+    input.optString("element_id")     // "experience"
+    input.optString("element_type")   // "single_choice"
+    input.optJSONObject("value")      // {"id": "pro", "title": "I train professionally"}
+}
+```
+</Details>
+
+<Details>
+<summary>Multi choice (Click to expand)</summary>
+
+```kotlin
+override fun onAnalyticEvent(name: String, params: Map<String, Any?>, context: Context) {
+    // payload, once decoded:
+    input.optString("element_id")    // "interests"
+    input.optString("element_type")  // "multi_choice"
+    input.optJSONArray("value")      // [{"id": "sports", "title": "Sports"},
+                                     //  {"id": "music",  "title": "Music"}]
+}
+```
+</Details>
+
+<Details>
+<summary>Toggle (Click to expand)</summary>
+
+```kotlin
+override fun onAnalyticEvent(name: String, params: Map<String, Any?>, context: Context) {
+    // payload, once decoded:
+    input.optString("element_id")    // "reminders"
+    input.optString("element_type")  // "toggle"
+    input.optBoolean("value")        // true
+}
+```
+</Details>
+
+## Delivery and limitations
+
+<FlowInputLimitations />
+
+The SDK tells you the flow closed through `onFlowClosed`. Collect answers as they arrive and act on the full set there.
+
+## Use cases
+
+### Register users on your backend
+
+Collect values as they arrive and send them once the flow closes, so that one request carries a complete set of answers.
+
+The flow closes whether a user finished it or abandoned it partway. Guard on the fields you need before you call your backend.
+
+```kotlin showLineNumbers title="Kotlin"
+class MyFlowEventListener : AdaptyFlowDefaultEventListener() {
+
+    private val flowAnswers = mutableMapOf<String, String>()
+
+    override fun onAnalyticEvent(
+        name: String,
+        params: Map<String, Any?>,
+        context: Context,
+    ) {
+        if (name != "flow_user_input") return
+
+        val payload = params["payload"] as? String ?: return
+        val input = JSONObject(payload)
+
+        flowAnswers[input.optString("element_id")] = input.optString("value")
+    }
+
+    override fun onFlowClosed() {
+        if (!flowAnswers.containsKey("email")) return
+
+        // Send flowAnswers to your backend here to create the account.
+
+        flowAnswers.clear()
+    }
+}
+```
+
+### Enrich user profiles with data
+
+To link what a user entered to their profile and avoid asking for the same details twice, [update the user profile](android-setting-user-attributes) as the values come in.
+
+For example, if your flow has a text input with the Element ID `name` and an email input with the Element ID `email`:
+
+```kotlin showLineNumbers title="Kotlin"
+private fun handleFlowInput(name: String, params: Map<String, Any?>) {
+    if (name != "flow_user_input") return
+
+    val payload = params["payload"] as? String ?: return
+    val input = JSONObject(payload)
+    val value = input.optString("value")
+
+    val builder = AdaptyProfileParameters.Builder()
+
+    when (input.optString("element_id")) {
+        "name" -> builder.withFirstName(value)
+        "email" -> builder.withEmail(value)
+        else -> return
+    }
+
+    Adapty.updateProfile(builder.build()) { error ->
+        if (error != null) {
+            // handle the error
+        }
+    }
+}
+```
+
+### Customize flows shown later
+
+Quiz answers can also decide what a user sees at a later [placement](placements) — a different flow, or a different paywall inside it.
+
+For example, ask users about their experience with sport in your onboarding flow, then show each group its own flow with different products and copy.
+
+1. Add a [quiz](onboarding-quizzes) to your flow and give each option a meaningful [Element ID](flow-selectable-elements).
+2. Handle the answers and [set custom attributes](android-setting-user-attributes) for the user.
+
+```kotlin showLineNumbers title="Kotlin"
+private fun handleFlowInput(name: String, params: Map<String, Any?>) {
+    if (name != "flow_user_input") return
+
+    val payload = params["payload"] as? String ?: return
+    val input = JSONObject(payload)
+    if (input.optString("element_id") != "experience") return
+
+    val optionId = input.optJSONObject("value")?.optString("id") ?: return
+
+    val builder = AdaptyProfileParameters.Builder()
+    // Set the custom attribute 'experience' to the option the user picked
+    // (beginner, amateur, or pro).
+    builder.withCustomAttribute("experience", optionId)
+
+    Adapty.updateProfile(builder.build()) { error ->
+        if (error != null) {
+            // handle the error
+        }
+    }
+}
+```
+
+3. [Create a segment](segments) for each custom attribute value.
+4. Create a [placement](placements) and add an [audience](audience) for each segment.
+5. [Display the flow](android-present-paywalls) for that placement in your app.

--- a/src/content/docs/android/android-handling-events.mdx
+++ b/src/content/docs/android/android-handling-events.mdx
@@ -481,6 +481,8 @@ public override fun onAnalyticEvent(
 
 See [Track flow screen views](android-flow-screen-views) for what to do with them.
 
+A flow also reports the values users type and select. See [Process data from flows](android-flow-input) to read them.
+
 ### Reserved events
 
 `AdaptyFlowEventListener` declares a few callbacks for functionality that flows don't use yet. You don't need to implement them — `AdaptyFlowDefaultEventListener` already provides no-op defaults.

--- a/src/content/docs/capacitor/capacitor-flow-input.mdx
+++ b/src/content/docs/capacitor/capacitor-flow-input.mdx
@@ -1,0 +1,280 @@
+---
+title: "Process data from flows in Capacitor SDK"
+description: "Save and use data your users enter in flows in your Capacitor app with Adapty SDK."
+metadataTitle: "Process data from flows | Capacitor SDK | Adapty Docs"
+---
+
+When a user types into an input field, answers a quiz, or flips a toggle in a [flow](adapty-flow-builder), the SDK passes the value to your app through its analytics callback.
+
+Apps most often use that data to:
+
+- **Register users on their own backend**: Take the email address and the name a user entered in your onboarding flow, and create their account without a second sign-up screen.
+- **Save answers and preferences**: Keep what a user picked so your app can act on it later, or [write it to their Adapty profile](capacitor-setting-user-attributes) as custom attributes.
+- **Customize the flows a user sees later**: Save quiz answers as custom attributes, then target a later placement so each segment gets a different flow, or a different paywall inside it.
+- **Feed your own analytics**: Forward answers to Amplitude, Mixpanel, or whichever product analytics you run.
+
+You don't set anything up in the builder — inputs and selectable groups report their values automatically.
+
+## Before you start
+
+You need:
+
+- **Adapty Capacitor SDK v4 or later**: The flow event handlers don't exist in earlier versions.
+- **A flow built in the [Flow Builder](adapty-flow-builder)**: Only flows report input values through this callback.
+- **A recently published flow version**: A flow reports input values only if you published it after this feature became available. If nothing reaches your handler, publish a new version of the flow and try again.
+
+## Receive input values
+
+Input values reach the same handler as every other analytics event from a flow, under the event name `flow_user_input`. Register `onAnalytics` alongside your other flow event handlers:
+
+```typescript showLineNumbers title="Capacitor"
+view.setEventHandlers({
+  onAnalytics(name, params) {
+    handleFlowInput(name, params);
+    return false; // keep the flow open
+  },
+});
+```
+
+A flow reports other analytics events through this handler as well, such as screen views. Match on `name` before you read anything else, or your handler will run on events that carry no input. See [Handle flow & paywall events](capacitor-handling-events) for the rest of them.
+
+`params.payload` is a JSON **string**, not an object — parse it before you read the answer:
+
+```typescript showLineNumbers title="Capacitor"
+function handleFlowInput(name: string, params: Record<string, unknown>) {
+  if (name !== 'flow_user_input') return;
+  if (typeof params.payload !== 'string') return;
+
+  const input = JSON.parse(params.payload);
+
+  // The screen the input sits on. Pair it with element_id to tell apart
+  // two fields that share an Element ID on different screens.
+  const screenId = params.instanceId;
+
+  switch (input.element_type) {
+    case 'text_input':
+    case 'email_input':
+    case 'number_input':
+    case 'phone_input': {
+      const text = input.value;
+      break;
+    }
+    case 'date_picker':
+    case 'time_picker':
+    case 'date_time_picker': {
+      const date = new Date(input.value);
+      break;
+    }
+    case 'single_choice': {
+      const option = input.value;
+      break;
+    }
+    case 'multi_choice': {
+      const options = input.value;
+      break;
+    }
+    case 'toggle': {
+      const isOn = input.value;
+      break;
+    }
+  }
+}
+```
+
+## What arrives in the handler
+
+| Parameter                | Description                                                                                                                                                                |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                   | The event name. Input values reach you as `flow_user_input`.                                                                                                               |
+| `params.instanceId`      | The ID of the screen the input is on. An Element ID is unique within one screen but can repeat across screens, so use `instanceId` together with `element_id` to tell two fields apart. |
+| `params.payload`         | A JSON string holding the answer. Parse it to read `element_id`, `element_type`, and `value`.                                                                              |
+| `params.isCustomerEvent` | `true` for events meant for your own analytics.                                                                                                                            |
+| `params.isBackendEvent`  | `false` for `flow_user_input`. Adapty doesn't receive or store what users enter — these values reach your app and nowhere else.                                            |
+
+The parsed `payload` holds:
+
+| Field          | Description                                                                                                     |
+|:---------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`      | The format version of the payload, currently `1`. Compare it against `1` before parsing to guard against later changes. |
+| `element_id`   | The **Element ID** of the input or selectable group the value came from.                                        |
+| `element_type` | The type of element that sent the value. It tells you how to read `value`.                                      |
+| `value`        | What the user entered or selected. Its shape depends on `element_type`.                                         |
+
+<FlowInputValueTypes />
+
+## Event examples
+
+These examples show the properties available on each event, with illustrative values in comments.
+
+<Details>
+<summary>Text, email, number, and phone input (Click to expand)</summary>
+
+```typescript
+onAnalytics(name, params) {
+  name;                      // 'flow_user_input'
+  params.instanceId;         // 'scr_J260KU5q'
+  params.isCustomerEvent;    // true
+  params.isBackendEvent;     // false
+  params.payload;            // '{"version":1,"element_id":"email","element_type":"email_input","value":"jane@example.com"}'
+
+  // payload, once parsed:
+  input.version;             // 1
+  input.element_id;          // 'email'
+  input.element_type;        // 'email_input'
+  input.value;               // 'jane@example.com'   (string)
+}
+```
+</Details>
+
+<Details>
+<summary>Date, time, and date-time pickers (Click to expand)</summary>
+
+```typescript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'birthday'
+  input.element_type;  // 'date_picker'
+  input.value;         // 645408000000   (Unix milliseconds — 1990-06-15)
+}
+```
+</Details>
+
+<Details>
+<summary>Single choice (Click to expand)</summary>
+
+```typescript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'experience'
+  input.element_type;  // 'single_choice'
+  input.value;         // { id: 'pro', title: 'I train professionally' }
+}
+```
+</Details>
+
+<Details>
+<summary>Multi choice (Click to expand)</summary>
+
+```typescript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'interests'
+  input.element_type;  // 'multi_choice'
+  input.value;         // [{ id: 'sports', title: 'Sports' },
+                       //  { id: 'music',  title: 'Music' }]
+}
+```
+</Details>
+
+<Details>
+<summary>Toggle (Click to expand)</summary>
+
+```typescript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'reminders'
+  input.element_type;  // 'toggle'
+  input.value;         // true   (boolean)
+}
+```
+</Details>
+
+## Delivery and limitations
+
+<FlowInputLimitations />
+
+The SDK tells you the flow closed through `onDisappeared`. Collect answers as they arrive and act on the full set there.
+
+## Use cases
+
+### Register users on your backend
+
+Collect values as they arrive and send them once the flow closes, so that one request carries a complete set of answers.
+
+The flow disappears whether a user finished it or abandoned it partway. Guard on the fields you need before you call your backend.
+
+```typescript showLineNumbers title="Capacitor"
+const flowAnswers: Record<string, unknown> = {};
+
+view.setEventHandlers({
+  onAnalytics(name, params) {
+    if (name === 'flow_user_input' && typeof params.payload === 'string') {
+      const input = JSON.parse(params.payload);
+      flowAnswers[input.element_id] = input.value;
+    }
+    return false;
+  },
+  onDisappeared() {
+    if (flowAnswers.email) {
+      // Send flowAnswers to your backend here to create the account.
+    }
+    return false;
+  },
+});
+```
+
+### Enrich user profiles with data
+
+To link what a user entered to their profile and avoid asking for the same details twice, [update the user profile](capacitor-setting-user-attributes) as the values come in.
+
+For example, if your flow has a text input with the Element ID `name` and an email input with the Element ID `email`:
+
+```typescript showLineNumbers title="Capacitor"
+function handleFlowInput(name: string, params: Record<string, unknown>) {
+  if (name !== 'flow_user_input') return;
+  if (typeof params.payload !== 'string') return;
+
+  const input = JSON.parse(params.payload);
+  const profileParams: any = {};
+
+  switch (input.element_id) {
+    case 'name':
+      profileParams.firstName = input.value;
+      break;
+    case 'email':
+      profileParams.email = input.value;
+      break;
+    default:
+      return;
+  }
+
+  adapty.updateProfile({ params: profileParams }).catch((error) => {
+    // handle the error
+  });
+}
+```
+
+### Customize flows shown later
+
+Quiz answers can also decide what a user sees at a later [placement](placements) — a different flow, or a different paywall inside it.
+
+For example, ask users about their experience with sport in your onboarding flow, then show each group its own flow with different products and copy.
+
+1. Add a [quiz](onboarding-quizzes) to your flow and give each option a meaningful [Element ID](flow-selectable-elements).
+2. Handle the answers and [set custom attributes](capacitor-setting-user-attributes) for the user.
+
+```typescript showLineNumbers title="Capacitor"
+function handleFlowInput(name: string, params: Record<string, unknown>) {
+  if (name !== 'flow_user_input') return;
+  if (typeof params.payload !== 'string') return;
+
+  const input = JSON.parse(params.payload);
+  if (input.element_id !== 'experience') return;
+
+  adapty
+    .updateProfile({
+      params: {
+        // Set the custom attribute 'experience' to the option the user picked
+        // (beginner, amateur, or pro).
+        codableCustomAttributes: { experience: input.value.id },
+      },
+    })
+    .catch((error) => {
+      // handle the error
+    });
+}
+```
+
+3. [Create a segment](segments) for each custom attribute value.
+4. Create a [placement](placements) and add an [audience](audience) for each segment.
+5. [Display the flow](capacitor-present-paywalls) for that placement in your app.

--- a/src/content/docs/capacitor/capacitor-handling-events.mdx
+++ b/src/content/docs/capacitor/capacitor-handling-events.mdx
@@ -164,6 +164,8 @@ view.setEventHandlers({
 
 See [Track flow screen views](capacitor-flow-screen-views) for what to do with them.
 
+A flow also reports the values users type and select. See [Process data from flows](capacitor-flow-input) to read them.
+
 ### Handle purchases in observer mode
 
 If you activated the SDK in [Observer mode](implement-observer-mode-capacitor) (`observerMode: true`) and present an Adapty-rendered flow, the SDK does not make purchases for you. When a user taps the purchase or restore button, the SDK invokes `onObserverPurchaseInitiated` or `onObserverRestoreInitiated` instead, so you can perform the purchase or restore with your own code. See [Present flows in Observer mode](capacitor-present-flows-in-observer-mode) for the full setup.

--- a/src/content/docs/flutter/flutter-flow-input.mdx
+++ b/src/content/docs/flutter/flutter-flow-input.mdx
@@ -1,0 +1,319 @@
+---
+title: "Process data from flows in Flutter SDK"
+description: "Save and use data your users enter in flows in your Flutter app with Adapty SDK."
+metadataTitle: "Process data from flows | Flutter SDK | Adapty Docs"
+---
+
+When a user types into an input field, answers a quiz, or flips a toggle in a [flow](adapty-flow-builder), the SDK passes the value to your app through its analytics callback.
+
+Apps most often use that data to:
+
+- **Register users on their own backend**: Take the email address and the name a user entered in your onboarding flow, and create their account without a second sign-up screen.
+- **Save answers and preferences**: Keep what a user picked so your app can act on it later, or [write it to their Adapty profile](flutter-setting-user-attributes) as custom attributes.
+- **Customize the flows a user sees later**: Save quiz answers as custom attributes, then target a later placement so each segment gets a different flow, or a different paywall inside it.
+- **Feed your own analytics**: Forward answers to Amplitude, Mixpanel, or whichever product analytics you run.
+
+You don't set anything up in the builder — inputs and selectable groups report their values automatically.
+
+## Before you start
+
+You need:
+
+- **Adapty Flutter SDK v4 or later**: The flow callbacks don't exist in earlier versions.
+- **A flow built in the [Flow Builder](adapty-flow-builder)**: Only flows report input values through this callback.
+- **A recently published flow version**: A flow reports input values only if you published it after this feature became available. If nothing reaches your callback, publish a new version of the flow and try again.
+
+## Receive input values
+
+Input values reach the same callback as every other analytics event from a flow, under the event name `flow_user_input`. Implement `flowViewDidReceiveAnalyticEvent` on the observer you register with `AdaptyUI().setFlowsEventsObserver`:
+
+```dart showLineNumbers title="Flutter"
+void flowViewDidReceiveAnalyticEvent(
+  AdaptyUIFlowView view,
+  String name,
+  Map<String, dynamic> params,
+) {
+  handleFlowInput(name, params);
+}
+```
+
+A flow reports other analytics events through this callback as well, such as screen views. Match on `name` before you read anything else, or your handler will run on events that carry no input. See [Handle flow & paywall events](flutter-handling-events) for the rest of them.
+
+`params['payload']` is a JSON **string**, not a map — decode it before you read the answer:
+
+```dart showLineNumbers title="Flutter"
+void handleFlowInput(String name, Map<String, dynamic> params) {
+  if (name != 'flow_user_input') return;
+
+  final payload = params['payload'];
+  if (payload is! String) return;
+
+  final input = jsonDecode(payload) as Map<String, dynamic>;
+  final elementId = input['element_id'] as String;
+
+  // The screen the input sits on. Pair it with elementId to tell apart
+  // two fields that share an Element ID on different screens.
+  final screenId = params['instanceId'] as String?;
+
+  switch (input['element_type'] as String) {
+    case 'text_input':
+    case 'email_input':
+    case 'number_input':
+    case 'phone_input':
+      final text = input['value'] as String;
+      break;
+    case 'date_picker':
+    case 'time_picker':
+    case 'date_time_picker':
+      final date = DateTime.fromMillisecondsSinceEpoch(input['value'] as int);
+      break;
+    case 'single_choice':
+      final option = input['value'] as Map<String, dynamic>;
+      break;
+    case 'multi_choice':
+      final options = input['value'] as List<dynamic>;
+      break;
+    case 'toggle':
+      final isOn = input['value'] as bool;
+      break;
+  }
+}
+```
+
+## What arrives in the callback
+
+| Parameter                   | Description                                                                                                                                                             |
+|:----------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                      | The event name. Input values reach you as `flow_user_input`.                                                                                                            |
+| `params['instanceId']`      | The ID of the screen the input is on. An Element ID is unique within one screen but can repeat across screens, so use `instanceId` together with `element_id` to tell two fields apart. |
+| `params['payload']`         | A JSON string holding the answer. Decode it to read `element_id`, `element_type`, and `value`.                                                                          |
+| `params['isCustomerEvent']` | `true` for events meant for your own analytics.                                                                                                                         |
+| `params['isBackendEvent']`  | `false` for `flow_user_input`. Adapty doesn't receive or store what users enter — these values reach your app and nowhere else.                                         |
+
+The decoded `payload` holds:
+
+| Field          | Description                                                                                                     |
+|:---------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`      | The format version of the payload, currently `1`. Compare it against `1` before decoding to guard against later changes. |
+| `element_id`   | The **Element ID** of the input or selectable group the value came from.                                        |
+| `element_type` | The type of element that sent the value. It tells you how to read `value`.                                      |
+| `value`        | What the user entered or selected. Its shape depends on `element_type`.                                         |
+
+<FlowInputValueTypes />
+
+## Event examples
+
+These examples show the properties available on each event, with illustrative values in comments.
+
+<Details>
+<summary>Text, email, number, and phone input (Click to expand)</summary>
+
+```dart
+void flowViewDidReceiveAnalyticEvent(
+  AdaptyUIFlowView view,
+  String name,
+  Map<String, dynamic> params,
+) {
+  name;                          // 'flow_user_input'
+  params['instanceId'];          // 'scr_J260KU5q'
+  params['isCustomerEvent'];     // true
+  params['isBackendEvent'];      // false
+  params['payload'];             // '{"version":1,"element_id":"email","element_type":"email_input","value":"jane@example.com"}'
+
+  // payload, once decoded:
+  input['version'];              // 1
+  input['element_id'];           // 'email'
+  input['element_type'];         // 'email_input'
+  input['value'];                // 'jane@example.com'   (String)
+}
+```
+</Details>
+
+<Details>
+<summary>Date, time, and date-time pickers (Click to expand)</summary>
+
+```dart
+void flowViewDidReceiveAnalyticEvent(
+  AdaptyUIFlowView view,
+  String name,
+  Map<String, dynamic> params,
+) {
+  // payload, once decoded:
+  input['element_id'];    // 'birthday'
+  input['element_type'];  // 'date_picker'
+  input['value'];         // 645408000000   (Unix milliseconds — 1990-06-15)
+}
+```
+</Details>
+
+<Details>
+<summary>Single choice (Click to expand)</summary>
+
+```dart
+void flowViewDidReceiveAnalyticEvent(
+  AdaptyUIFlowView view,
+  String name,
+  Map<String, dynamic> params,
+) {
+  // payload, once decoded:
+  input['element_id'];    // 'experience'
+  input['element_type'];  // 'single_choice'
+  input['value'];         // {'id': 'pro', 'title': 'I train professionally'}
+}
+```
+</Details>
+
+<Details>
+<summary>Multi choice (Click to expand)</summary>
+
+```dart
+void flowViewDidReceiveAnalyticEvent(
+  AdaptyUIFlowView view,
+  String name,
+  Map<String, dynamic> params,
+) {
+  // payload, once decoded:
+  input['element_id'];    // 'interests'
+  input['element_type'];  // 'multi_choice'
+  input['value'];         // [{'id': 'sports', 'title': 'Sports'},
+                          //  {'id': 'music',  'title': 'Music'}]
+}
+```
+</Details>
+
+<Details>
+<summary>Toggle (Click to expand)</summary>
+
+```dart
+void flowViewDidReceiveAnalyticEvent(
+  AdaptyUIFlowView view,
+  String name,
+  Map<String, dynamic> params,
+) {
+  // payload, once decoded:
+  input['element_id'];    // 'reminders'
+  input['element_type'];  // 'toggle'
+  input['value'];         // true   (bool)
+}
+```
+</Details>
+
+## Delivery and limitations
+
+<FlowInputLimitations />
+
+The SDK tells you the flow closed through `flowViewDidDisappear`. Collect answers as they arrive and act on the full set there.
+
+## Use cases
+
+### Register users on your backend
+
+Collect values as they arrive and send them once the flow closes, so that one request carries a complete set of answers.
+
+The view disappears whether a user finished the flow or abandoned it partway. Guard on the fields you need before you call your backend.
+
+```dart showLineNumbers title="Flutter"
+final Map<String, String> flowAnswers = {};
+
+void flowViewDidReceiveAnalyticEvent(
+  AdaptyUIFlowView view,
+  String name,
+  Map<String, dynamic> params,
+) {
+  if (name != 'flow_user_input') return;
+
+  final payload = params['payload'];
+  if (payload is! String) return;
+
+  final input = jsonDecode(payload) as Map<String, dynamic>;
+  final value = input['value'];
+  if (value is! String) return;
+
+  flowAnswers[input['element_id'] as String] = value;
+}
+
+void flowViewDidDisappear(AdaptyUIFlowView view) {
+  if (!flowAnswers.containsKey('email')) return;
+
+  // Send flowAnswers to your backend here to create the account.
+
+  flowAnswers.clear();
+}
+```
+
+### Enrich user profiles with data
+
+To link what a user entered to their profile and avoid asking for the same details twice, [update the user profile](flutter-setting-user-attributes) as the values come in.
+
+For example, if your flow has a text input with the Element ID `name` and an email input with the Element ID `email`:
+
+```dart showLineNumbers title="Flutter"
+void handleFlowInput(String name, Map<String, dynamic> params) async {
+  if (name != 'flow_user_input') return;
+
+  final payload = params['payload'];
+  if (payload is! String) return;
+
+  final input = jsonDecode(payload) as Map<String, dynamic>;
+  final value = input['value'];
+  if (value is! String) return;
+
+  final builder = AdaptyProfileParametersBuilder();
+
+  switch (input['element_id'] as String) {
+    case 'name':
+      builder.setFirstName(value);
+      break;
+    case 'email':
+      builder.setEmail(value);
+      break;
+    default:
+      return;
+  }
+
+  try {
+    await Adapty().updateProfile(builder.build());
+  } on AdaptyError catch (adaptyError) {
+    // handle the error
+  }
+}
+```
+
+### Customize flows shown later
+
+Quiz answers can also decide what a user sees at a later [placement](placements) — a different flow, or a different paywall inside it.
+
+For example, ask users about their experience with sport in your onboarding flow, then show each group its own flow with different products and copy.
+
+1. Add a [quiz](onboarding-quizzes) to your flow and give each option a meaningful [Element ID](flow-selectable-elements).
+2. Handle the answers and [set custom attributes](flutter-setting-user-attributes) for the user.
+
+```dart showLineNumbers title="Flutter"
+void handleFlowInput(String name, Map<String, dynamic> params) async {
+  if (name != 'flow_user_input') return;
+
+  final payload = params['payload'];
+  if (payload is! String) return;
+
+  final input = jsonDecode(payload) as Map<String, dynamic>;
+  if (input['element_id'] != 'experience') return;
+
+  final option = input['value'] as Map<String, dynamic>;
+  final optionId = option['id'] as String;
+
+  final builder = AdaptyProfileParametersBuilder();
+  // Set the custom attribute 'experience' to the option the user picked
+  // (beginner, amateur, or pro).
+  builder.setCustomStringAttribute(optionId, 'experience');
+
+  try {
+    await Adapty().updateProfile(builder.build());
+  } on AdaptyError catch (adaptyError) {
+    // handle the error
+  }
+}
+```
+
+3. [Create a segment](segments) for each custom attribute value.
+4. Create a [placement](placements) and add an [audience](audience) for each segment.
+5. [Display the flow](flutter-present-paywalls) for that placement in your app.

--- a/src/content/docs/flutter/flutter-handling-events.mdx
+++ b/src/content/docs/flutter/flutter-handling-events.mdx
@@ -268,6 +268,8 @@ void flowViewDidReceiveAnalyticEvent(
 
 See [Track flow screen views](flutter-flow-screen-views) for what to do with them.
 
+A flow also reports the values users type and select. See [Process data from flows](flutter-flow-input) to read them.
+
 ### Handle purchases in observer mode
 
 If you activated the SDK in [Observer mode](implement-observer-mode-flutter) and present an Adapty-rendered flow or paywall, the SDK does not make purchases for you. When a user taps the purchase or restore button, the SDK calls your `AdaptyUIObserverModeResolver` instead. See [Present flows in Observer mode](flutter-present-flows-in-observer-mode) for the full setup.

--- a/src/content/docs/ios/ios-flow-input.mdx
+++ b/src/content/docs/ios/ios-flow-input.mdx
@@ -1,0 +1,317 @@
+---
+title: "Process data from flows in iOS SDK"
+description: "Save and use data your users enter in flows in your iOS app with Adapty SDK."
+metadataTitle: "Process data from flows | iOS SDK | Adapty Docs"
+---
+
+When a user types into an input field, answers a quiz, or flips a toggle in a [flow](adapty-flow-builder), the SDK passes the value to your app through its analytics callback.
+
+Apps most often use that data to:
+
+- **Register users on their own backend**: Take the email address and the name a user entered in your onboarding flow, and create their account without a second sign-up screen.
+- **Save answers and preferences**: Keep what a user picked so your app can act on it later, or [write it to their Adapty profile](setting-user-attributes) as custom attributes.
+- **Customize the flows a user sees later**: Save quiz answers as custom attributes, then target a later placement so each segment gets a different flow, or a different paywall inside it.
+- **Feed your own analytics**: Forward answers to Amplitude, Mixpanel, or whichever product analytics you run.
+
+You don't set anything up in the builder — inputs and selectable groups report their values automatically.
+
+## Before you start
+
+You need:
+
+- **Adapty iOS SDK v4 or later**: The flow callbacks don't exist in earlier versions.
+- **A flow built in the [Flow Builder](adapty-flow-builder)**: Only flows report input values through this callback.
+- **A recently published flow version**: A flow reports input values only if you published it after this feature became available. If nothing reaches your callback, publish a new version of the flow and try again.
+
+## Receive input values
+
+Input values reach the same callback as every other analytics event from a flow, under the event name `flow_user_input`. Register the callback alongside your other flow event handlers.
+
+<Tabs>
+<TabItem value="swiftui" label="SwiftUI" default>
+
+Pass a `didReceiveAnalyticEvent` closure to the `.flow` modifier:
+
+```swift showLineNumbers title="Swift"
+Text("Hello, AdaptyUI!")
+    .flow(
+        isPresented: $flowPresented,
+        flowConfiguration: flowConfiguration,
+        didFinishPurchase: { product, purchaseResult in /* handle the event */ },
+        didFailPurchase: { product, error in /* handle the error */ },
+        didFinishRestore: { profile in /* handle the event */ },
+        didFailRestore: { error in /* handle the error */ },
+        didReceiveError: { error in flowPresented = false },
+        didReceiveAnalyticEvent: { name, params in
+            handleFlowInput(name: name, params: params)
+        }
+    )
+```
+
+</TabItem>
+<TabItem value="uikit" label="UIKit">
+
+Implement the method on your `AdaptyFlowControllerDelegate`:
+
+```swift showLineNumbers title="Swift"
+func flowController(
+    _ controller: AdaptyFlowController,
+    didReceiveAnalyticEvent name: String,
+    params: [String: any Sendable]
+) {
+    handleFlowInput(name: name, params: params)
+}
+```
+
+</TabItem>
+</Tabs>
+
+The closure and the delegate method receive the same two arguments, so the code that reads the value is the same either way.
+
+A flow reports other analytics events through this callback as well, such as screen views. Match on `name` before you read anything else, or your handler will run on events that carry no input. See [Handle flow & paywall events](ios-handling-events) for the rest of them.
+
+`params["payload"]` is a JSON **string**, not a dictionary — decode it before you read the answer:
+
+```swift showLineNumbers title="Swift"
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    guard name == "flow_user_input",
+          let payload = params["payload"] as? String,
+          let data = payload.data(using: .utf8),
+          let input = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let elementId = input["element_id"] as? String,
+          let elementType = input["element_type"] as? String
+    else { return }
+
+    // The screen the input sits on. Pair it with elementId to tell apart
+    // two fields that share an Element ID on different screens.
+    let screenId = params["instanceId"] as? String
+
+    switch elementType {
+    case "text_input", "email_input", "number_input", "phone_input":
+        let text = input["value"] as? String
+    case "date_picker", "time_picker", "date_time_picker":
+        let date = (input["value"] as? Double).map { Date(timeIntervalSince1970: $0 / 1000) }
+    case "single_choice":
+        let option = input["value"] as? [String: Any]
+    case "multi_choice":
+        let options = input["value"] as? [[String: Any]]
+    case "toggle":
+        let isOn = input["value"] as? Bool
+    default:
+        break
+    }
+}
+```
+
+## What arrives in the callback
+
+| Parameter                  | Description                                                                                                                                                              |
+|:---------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                     | The event name. Input values reach you as `flow_user_input`.                                                                                                             |
+| `params["instanceId"]`     | The ID of the screen the input is on. An Element ID is unique within one screen but can repeat across screens, so use `instanceId` together with `element_id` to tell two fields apart. |
+| `params["payload"]`        | A JSON string holding the answer. Decode it to read `element_id`, `element_type`, and `value`.                                                                           |
+| `params["isCustomerEvent"]` | `true` for events meant for your own analytics.                                                                                                                          |
+| `params["isBackendEvent"]` | `false` for `flow_user_input`. Adapty doesn't receive or store what users enter — these values reach your app and nowhere else.                                          |
+
+The decoded `payload` holds:
+
+| Field          | Description                                                                                                     |
+|:---------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`      | The format version of the payload, currently `1`. Compare it against `1` before decoding to guard against later changes. |
+| `element_id`   | The **Element ID** of the input or selectable group the value came from.                                        |
+| `element_type` | The type of element that sent the value. It tells you how to read `value`.                                      |
+| `value`        | What the user entered or selected. Its shape depends on `element_type`.                                         |
+
+<FlowInputValueTypes />
+
+## Event examples
+
+These examples show the properties available on each event, with illustrative values in comments.
+
+<Details>
+<summary>Text, email, number, and phone input (Click to expand)</summary>
+
+```swift
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    name;                        // "flow_user_input"
+    params["instanceId"];        // "scr_J260KU5q"
+    params["isCustomerEvent"];   // true
+    params["isBackendEvent"];    // false
+    params["payload"];           // "{\"version\":1,\"element_id\":\"email\",\"element_type\":\"email_input\",\"value\":\"jane@example.com\"}"
+
+    // payload, once decoded:
+    input["version"];            // 1
+    input["element_id"];         // "email"
+    input["element_type"];       // "email_input"
+    input["value"];              // "jane@example.com"   (String)
+}
+```
+</Details>
+
+<Details>
+<summary>Date, time, and date-time pickers (Click to expand)</summary>
+
+```swift
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    // payload, once decoded:
+    input["element_id"];    // "birthday"
+    input["element_type"];  // "date_picker"
+    input["value"];         // 645408000000   (Unix milliseconds — 1990-06-15)
+}
+```
+</Details>
+
+<Details>
+<summary>Single choice (Click to expand)</summary>
+
+```swift
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    // payload, once decoded:
+    input["element_id"];    // "experience"
+    input["element_type"];  // "single_choice"
+    input["value"];         // ["id": "pro", "title": "I train professionally"]
+}
+```
+</Details>
+
+<Details>
+<summary>Multi choice (Click to expand)</summary>
+
+```swift
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    // payload, once decoded:
+    input["element_id"];    // "interests"
+    input["element_type"];  // "multi_choice"
+    input["value"];         // [["id": "sports", "title": "Sports"],
+                            //  ["id": "music",  "title": "Music"]]
+}
+```
+</Details>
+
+<Details>
+<summary>Toggle (Click to expand)</summary>
+
+```swift
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    // payload, once decoded:
+    input["element_id"];    // "reminders"
+    input["element_type"];  // "toggle"
+    input["value"];         // true   (Bool)
+}
+```
+</Details>
+
+## Delivery and limitations
+
+<FlowInputLimitations />
+
+The SDK tells you the flow closed through `flowControllerDidDisappear` in UIKit, or the `didDisappear` closure in SwiftUI. Collect answers as they arrive and act on the full set there.
+
+## Use cases
+
+### Register users on your backend
+
+Collect values as they arrive and send them once the flow closes, so that one request carries a complete set of answers.
+
+The view disappears whether a user finished the flow or abandoned it partway. Guard on the fields you need before you call your backend.
+
+```swift showLineNumbers title="Swift"
+private var flowAnswers: [String: String] = [:]
+
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    guard name == "flow_user_input",
+          let payload = params["payload"] as? String,
+          let data = payload.data(using: .utf8),
+          let input = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let elementId = input["element_id"] as? String,
+          let value = input["value"] as? String
+    else { return }
+
+    flowAnswers[elementId] = value
+}
+
+func flowControllerDidDisappear(_ controller: AdaptyFlowController) {
+    guard flowAnswers["email"] != nil else { return }
+
+    // Send flowAnswers to your backend here to create the account.
+
+    flowAnswers.removeAll()
+}
+```
+
+### Enrich user profiles with data
+
+To link what a user entered to their profile and avoid asking for the same details twice, [update the user profile](setting-user-attributes) as the values come in.
+
+For example, if your flow has a text input with the Element ID `name` and an email input with the Element ID `email`:
+
+```swift showLineNumbers title="Swift"
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    guard name == "flow_user_input",
+          let payload = params["payload"] as? String,
+          let data = payload.data(using: .utf8),
+          let input = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let elementId = input["element_id"] as? String,
+          let value = input["value"] as? String
+    else { return }
+
+    let builder = AdaptyProfileParameters.Builder()
+
+    switch elementId {
+    case "name":
+        builder.with(firstName: value)
+    case "email":
+        builder.with(email: value)
+    default:
+        return
+    }
+
+    // Delegate methods are synchronous; kick off the async update in a Task.
+    Task {
+        do {
+            try await Adapty.updateProfile(params: builder.build())
+        } catch {
+            // handle the error
+        }
+    }
+}
+```
+
+### Customize flows shown later
+
+Quiz answers can also decide what a user sees at a later [placement](placements) — a different flow, or a different paywall inside it.
+
+For example, ask users about their experience with sport in your onboarding flow, then show each group its own flow with different products and copy.
+
+1. Add a [quiz](onboarding-quizzes) to your flow and give each option a meaningful [Element ID](flow-selectable-elements).
+2. Handle the answers and [set custom attributes](setting-user-attributes) for the user.
+
+```swift showLineNumbers title="Swift"
+func handleFlowInput(name: String, params: [String: any Sendable]) {
+    guard name == "flow_user_input",
+          let payload = params["payload"] as? String,
+          let data = payload.data(using: .utf8),
+          let input = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          input["element_id"] as? String == "experience",
+          let option = input["value"] as? [String: Any],
+          let optionId = option["id"] as? String
+    else { return }
+
+    let builder = AdaptyProfileParameters.Builder()
+    // Set the custom attribute 'experience' to the option the user picked
+    // (beginner, amateur, or pro).
+    try? builder.with(customAttribute: optionId, forKey: "experience")
+
+    Task {
+        do {
+            try await Adapty.updateProfile(params: builder.build())
+        } catch {
+            // handle the error
+        }
+    }
+}
+```
+
+3. [Create a segment](segments) for each custom attribute value.
+4. Create a [placement](placements) and add an [audience](audience) for each segment.
+5. [Display the flow](ios-present-paywalls) for that placement in your app.

--- a/src/content/docs/ios/ios-handling-events.mdx
+++ b/src/content/docs/ios/ios-handling-events.mdx
@@ -222,6 +222,8 @@ func flowController(
 
 See [Track flow screen views](ios-flow-screen-views) for what to do with them.
 
+A flow also reports the values users type and select. See [Process data from flows](ios-flow-input) to read them.
+
 </SDKv4>
 
 <SDKv3>

--- a/src/content/docs/kmp/kmp-flow-input.mdx
+++ b/src/content/docs/kmp/kmp-flow-input.mdx
@@ -1,0 +1,320 @@
+---
+title: "Process data from flows in Kotlin Multiplatform SDK"
+description: "Save and use data your users enter in flows in your Kotlin Multiplatform app with Adapty SDK."
+metadataTitle: "Process data from flows | Kotlin Multiplatform SDK | Adapty Docs"
+---
+
+When a user types into an input field, answers a quiz, or flips a toggle in a [flow](adapty-flow-builder), the SDK passes the value to your app through its analytics callback.
+
+Apps most often use that data to:
+
+- **Register users on their own backend**: Take the email address and the name a user entered in your onboarding flow, and create their account without a second sign-up screen.
+- **Save answers and preferences**: Keep what a user picked so your app can act on it later, or [write it to their Adapty profile](kmp-setting-user-attributes) as custom attributes.
+- **Customize the flows a user sees later**: Save quiz answers as custom attributes, then target a later placement so each segment gets a different flow, or a different paywall inside it.
+- **Feed your own analytics**: Forward answers to Amplitude, Mixpanel, or whichever product analytics you run.
+
+You don't set anything up in the builder — inputs and selectable groups report their values automatically.
+
+## Before you start
+
+You need:
+
+- **Adapty Kotlin Multiplatform SDK v4 or later**: The flow callbacks don't exist in earlier versions.
+- **A flow built in the [Flow Builder](adapty-flow-builder)**: Only flows report input values through this callback.
+- **A recently published flow version**: A flow reports input values only if you published it after this feature became available. If nothing reaches your observer, publish a new version of the flow and try again.
+
+## Receive input values
+
+Input values reach the same callback as every other analytics event from a flow, under the event name `flow_user_input`. Override `flowViewDidReceiveAnalyticEvent` on the observer you register with `AdaptyUI.setFlowsEventsObserver`:
+
+```kotlin showLineNumbers title="Kotlin"
+AdaptyUI.setFlowsEventsObserver(object : AdaptyUIFlowsEventsObserver {
+
+    override fun flowViewDidReceiveAnalyticEvent(
+        view: AdaptyUIFlowView,
+        name: String,
+        paramsJsonString: String,
+    ) {
+        handleFlowInput(name, paramsJsonString)
+    }
+})
+```
+
+A flow reports other analytics events through this callback as well, such as screen views. Match on `name` before you read anything else, or your observer will run on events that carry no input. See [Handle flow & paywall events](kmp-handling-events) for the rest of them.
+
+Kotlin Multiplatform hands you the event parameters as a raw JSON string, and the answer sits in a JSON string nested inside it. That means two decodes: first `paramsJsonString`, then the `payload` string you find in it.
+
+```kotlin showLineNumbers title="Kotlin"
+private fun handleFlowInput(name: String, paramsJsonString: String) {
+    if (name != "flow_user_input") return
+
+    // First decode: the event parameters.
+    val params = Json.parseToJsonElement(paramsJsonString).jsonObject
+    val payload = params["payload"]?.jsonPrimitive?.contentOrNull ?: return
+
+    // Second decode: the answer itself.
+    val input = Json.parseToJsonElement(payload).jsonObject
+    val elementId = input["element_id"]?.jsonPrimitive?.content
+
+    // The screen the input sits on. Pair it with elementId to tell apart
+    // two fields that share an Element ID on different screens.
+    val screenId = params["instanceId"]?.jsonPrimitive?.contentOrNull
+
+    when (input["element_type"]?.jsonPrimitive?.content) {
+        "text_input", "email_input", "number_input", "phone_input" -> {
+            val text = input["value"]?.jsonPrimitive?.content
+        }
+        "date_picker", "time_picker", "date_time_picker" -> {
+            val millis = input["value"]?.jsonPrimitive?.long
+        }
+        "single_choice" -> {
+            val option = input["value"]?.jsonObject
+        }
+        "multi_choice" -> {
+            val options = input["value"]?.jsonArray
+        }
+        "toggle" -> {
+            val isOn = input["value"]?.jsonPrimitive?.boolean
+        }
+    }
+}
+```
+
+## What arrives in the callback
+
+| Parameter          | Description                                                                                                                                                                      |
+|:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`             | The event name. Input values reach you as `flow_user_input`.                                                                                                                     |
+| `paramsJsonString` | Every other field, as a raw JSON string. Decode it to read `instanceId`, `payload`, `isCustomerEvent`, and `isBackendEvent`.                                                     |
+| `instanceId`       | The ID of the screen the input is on. An Element ID is unique within one screen but can repeat across screens, so use `instanceId` together with `element_id` to tell two fields apart. |
+| `payload`          | A JSON string holding the answer. Decode it a second time to read `element_id`, `element_type`, and `value`.                                                                     |
+| `isCustomerEvent`  | `true` for events meant for your own analytics.                                                                                                                                  |
+| `isBackendEvent`   | `false` for `flow_user_input`. Adapty doesn't receive or store what users enter — these values reach your app and nowhere else.                                                  |
+
+The decoded `payload` holds:
+
+| Field          | Description                                                                                                     |
+|:---------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`      | The format version of the payload, currently `1`. Compare it against `1` before decoding to guard against later changes. |
+| `element_id`   | The **Element ID** of the input or selectable group the value came from.                                        |
+| `element_type` | The type of element that sent the value. It tells you how to read `value`.                                      |
+| `value`        | What the user entered or selected. Its shape depends on `element_type`.                                         |
+
+<FlowInputValueTypes />
+
+## Event examples
+
+These examples show the properties available on each event, with illustrative values in comments.
+
+<Details>
+<summary>Text, email, number, and phone input (Click to expand)</summary>
+
+```kotlin
+override fun flowViewDidReceiveAnalyticEvent(
+    view: AdaptyUIFlowView,
+    name: String,
+    paramsJsonString: String,
+) {
+    name                // "flow_user_input"
+    paramsJsonString    // "{\"instanceId\":\"scr_J260KU5q\",\"isBackendEvent\":false,\"isCustomerEvent\":true,\"payload\":\"{...}\"}"
+
+    // paramsJsonString, once decoded:
+    params["instanceId"]        // "scr_J260KU5q"
+    params["isCustomerEvent"]   // true
+    params["isBackendEvent"]    // false
+    params["payload"]           // "{\"version\":1,\"element_id\":\"email\",\"element_type\":\"email_input\",\"value\":\"jane@example.com\"}"
+
+    // payload, once decoded a second time:
+    input["version"]        // 1
+    input["element_id"]     // "email"
+    input["element_type"]   // "email_input"
+    input["value"]          // "jane@example.com"
+}
+```
+</Details>
+
+<Details>
+<summary>Date, time, and date-time pickers (Click to expand)</summary>
+
+```kotlin
+override fun flowViewDidReceiveAnalyticEvent(
+    view: AdaptyUIFlowView,
+    name: String,
+    paramsJsonString: String,
+) {
+    // payload, once decoded:
+    input["element_id"]     // "birthday"
+    input["element_type"]   // "date_picker"
+    input["value"]          // 645408000000   (Unix milliseconds — 1990-06-15)
+}
+```
+</Details>
+
+<Details>
+<summary>Single choice (Click to expand)</summary>
+
+```kotlin
+override fun flowViewDidReceiveAnalyticEvent(
+    view: AdaptyUIFlowView,
+    name: String,
+    paramsJsonString: String,
+) {
+    // payload, once decoded:
+    input["element_id"]     // "experience"
+    input["element_type"]   // "single_choice"
+    input["value"]          // {"id": "pro", "title": "I train professionally"}
+}
+```
+</Details>
+
+<Details>
+<summary>Multi choice (Click to expand)</summary>
+
+```kotlin
+override fun flowViewDidReceiveAnalyticEvent(
+    view: AdaptyUIFlowView,
+    name: String,
+    paramsJsonString: String,
+) {
+    // payload, once decoded:
+    input["element_id"]     // "interests"
+    input["element_type"]   // "multi_choice"
+    input["value"]          // [{"id": "sports", "title": "Sports"},
+                            //  {"id": "music",  "title": "Music"}]
+}
+```
+</Details>
+
+<Details>
+<summary>Toggle (Click to expand)</summary>
+
+```kotlin
+override fun flowViewDidReceiveAnalyticEvent(
+    view: AdaptyUIFlowView,
+    name: String,
+    paramsJsonString: String,
+) {
+    // payload, once decoded:
+    input["element_id"]     // "reminders"
+    input["element_type"]   // "toggle"
+    input["value"]          // true
+}
+```
+</Details>
+
+## Delivery and limitations
+
+<FlowInputLimitations />
+
+The SDK tells you the flow closed through `flowViewDidDisappear`. Collect answers as they arrive and act on the full set there.
+
+## Use cases
+
+### Register users on your backend
+
+Collect values as they arrive and send them once the flow closes, so that one request carries a complete set of answers.
+
+The view disappears whether a user finished the flow or abandoned it partway. Guard on the fields you need before you call your backend.
+
+```kotlin showLineNumbers title="Kotlin"
+class MyFlowsEventsObserver : AdaptyUIFlowsEventsObserver {
+
+    private val flowAnswers = mutableMapOf<String, String>()
+
+    override fun flowViewDidReceiveAnalyticEvent(
+        view: AdaptyUIFlowView,
+        name: String,
+        paramsJsonString: String,
+    ) {
+        if (name != "flow_user_input") return
+
+        val params = Json.parseToJsonElement(paramsJsonString).jsonObject
+        val payload = params["payload"]?.jsonPrimitive?.contentOrNull ?: return
+        val input = Json.parseToJsonElement(payload).jsonObject
+
+        val elementId = input["element_id"]?.jsonPrimitive?.content ?: return
+        val value = input["value"]?.jsonPrimitive?.contentOrNull ?: return
+
+        flowAnswers[elementId] = value
+    }
+
+    override fun flowViewDidDisappear(view: AdaptyUIFlowView) {
+        if (!flowAnswers.containsKey("email")) return
+
+        // Send flowAnswers to your backend here to create the account.
+
+        flowAnswers.clear()
+    }
+}
+```
+
+### Enrich user profiles with data
+
+To link what a user entered to their profile and avoid asking for the same details twice, [update the user profile](kmp-setting-user-attributes) as the values come in.
+
+For example, if your flow has a text input with the Element ID `name` and an email input with the Element ID `email`:
+
+```kotlin showLineNumbers title="Kotlin"
+private fun handleFlowInput(name: String, paramsJsonString: String) {
+    if (name != "flow_user_input") return
+
+    val params = Json.parseToJsonElement(paramsJsonString).jsonObject
+    val payload = params["payload"]?.jsonPrimitive?.contentOrNull ?: return
+    val input = Json.parseToJsonElement(payload).jsonObject
+    val value = input["value"]?.jsonPrimitive?.contentOrNull ?: return
+
+    val builder = AdaptyProfileParameters.Builder()
+
+    when (input["element_id"]?.jsonPrimitive?.content) {
+        "name" -> builder.withFirstName(value)
+        "email" -> builder.withEmail(value)
+        else -> return
+    }
+
+    mainUiScope.launch {
+        Adapty.updateProfile(builder.build())
+            .onError { error ->
+                // handle the error
+            }
+    }
+}
+```
+
+### Customize flows shown later
+
+Quiz answers can also decide what a user sees at a later [placement](placements) — a different flow, or a different paywall inside it.
+
+For example, ask users about their experience with sport in your onboarding flow, then show each group its own flow with different products and copy.
+
+1. Add a [quiz](onboarding-quizzes) to your flow and give each option a meaningful [Element ID](flow-selectable-elements).
+2. Handle the answers and [set custom attributes](kmp-setting-user-attributes) for the user.
+
+```kotlin showLineNumbers title="Kotlin"
+private fun handleFlowInput(name: String, paramsJsonString: String) {
+    if (name != "flow_user_input") return
+
+    val params = Json.parseToJsonElement(paramsJsonString).jsonObject
+    val payload = params["payload"]?.jsonPrimitive?.contentOrNull ?: return
+    val input = Json.parseToJsonElement(payload).jsonObject
+    if (input["element_id"]?.jsonPrimitive?.content != "experience") return
+
+    val optionId = input["value"]?.jsonObject
+        ?.get("id")?.jsonPrimitive?.contentOrNull ?: return
+
+    val builder = AdaptyProfileParameters.Builder()
+    // Set the custom attribute 'experience' to the option the user picked
+    // (beginner, amateur, or pro).
+    builder.withCustomAttribute("experience", optionId)
+
+    mainUiScope.launch {
+        Adapty.updateProfile(builder.build())
+            .onError { error ->
+                // handle the error
+            }
+    }
+}
+```
+
+3. [Create a segment](segments) for each custom attribute value.
+4. Create a [placement](placements) and add an [audience](audience) for each segment.
+5. [Display the flow](kmp-present-paywalls) for that placement in your app.

--- a/src/content/docs/kmp/kmp-handling-events.mdx
+++ b/src/content/docs/kmp/kmp-handling-events.mdx
@@ -457,6 +457,8 @@ Kotlin Multiplatform hands you the event parameters as a raw JSON string, so dec
 
 See [Track flow screen views](kmp-flow-screen-views) for what to do with them.
 
+A flow also reports the values users type and select. See [Process data from flows](kmp-flow-input) to read them.
+
 ### Navigation
 
 #### Android system back button

--- a/src/content/docs/react-native/react-native-flow-input.mdx
+++ b/src/content/docs/react-native/react-native-flow-input.mdx
@@ -1,0 +1,278 @@
+---
+title: "Process data from flows in React Native SDK"
+description: "Save and use data your users enter in flows in your React Native app with Adapty SDK."
+metadataTitle: "Process data from flows | React Native SDK | Adapty Docs"
+---
+
+When a user types into an input field, answers a quiz, or flips a toggle in a [flow](adapty-flow-builder), the SDK passes the value to your app through its analytics callback.
+
+Apps most often use that data to:
+
+- **Register users on their own backend**: Take the email address and the name a user entered in your onboarding flow, and create their account without a second sign-up screen.
+- **Save answers and preferences**: Keep what a user picked so your app can act on it later, or [write it to their Adapty profile](react-native-setting-user-attributes) as custom attributes.
+- **Customize the flows a user sees later**: Save quiz answers as custom attributes, then target a later placement so each segment gets a different flow, or a different paywall inside it.
+- **Feed your own analytics**: Forward answers to Amplitude, Mixpanel, or whichever product analytics you run.
+
+You don't set anything up in the builder — inputs and selectable groups report their values automatically.
+
+## Before you start
+
+You need:
+
+- **Adapty React Native SDK v4 or later**: The flow event handlers don't exist in earlier versions.
+- **A flow built in the [Flow Builder](adapty-flow-builder)**: Only flows report input values through this callback.
+- **A recently published flow version**: A flow reports input values only if you published it after this feature became available. If nothing reaches your handler, publish a new version of the flow and try again.
+
+## Receive input values
+
+Input values reach the same handler as every other analytics event from a flow, under the event name `flow_user_input`. Register `onAnalytics` alongside your other flow event handlers:
+
+```javascript showLineNumbers title="React Native"
+const unsubscribe = view.setEventHandlers({
+  onAnalytics(name, params) {
+    handleFlowInput(name, params);
+    return false; // keep the flow open
+  },
+});
+```
+
+A flow reports other analytics events through this handler as well, such as screen views. Match on `name` before you read anything else, or your handler will run on events that carry no input. See [Handle flow & paywall events](react-native-handling-events-1) for the rest of them.
+
+`params.payload` is a JSON **string**, not an object — parse it before you read the answer:
+
+```javascript showLineNumbers title="React Native"
+function handleFlowInput(name, params) {
+  if (name !== 'flow_user_input') return;
+  if (typeof params.payload !== 'string') return;
+
+  const input = JSON.parse(params.payload);
+
+  // The screen the input sits on. Pair it with element_id to tell apart
+  // two fields that share an Element ID on different screens.
+  const screenId = params.instanceId;
+
+  switch (input.element_type) {
+    case 'text_input':
+    case 'email_input':
+    case 'number_input':
+    case 'phone_input': {
+      const text = input.value;
+      break;
+    }
+    case 'date_picker':
+    case 'time_picker':
+    case 'date_time_picker': {
+      const date = new Date(input.value);
+      break;
+    }
+    case 'single_choice': {
+      const option = input.value;
+      break;
+    }
+    case 'multi_choice': {
+      const options = input.value;
+      break;
+    }
+    case 'toggle': {
+      const isOn = input.value;
+      break;
+    }
+  }
+}
+```
+
+## What arrives in the handler
+
+| Parameter                | Description                                                                                                                                                                |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                   | The event name. Input values reach you as `flow_user_input`.                                                                                                               |
+| `params.instanceId`      | The ID of the screen the input is on. An Element ID is unique within one screen but can repeat across screens, so use `instanceId` together with `element_id` to tell two fields apart. |
+| `params.payload`         | A JSON string holding the answer. Parse it to read `element_id`, `element_type`, and `value`.                                                                              |
+| `params.isCustomerEvent` | `true` for events meant for your own analytics.                                                                                                                            |
+| `params.isBackendEvent`  | `false` for `flow_user_input`. Adapty doesn't receive or store what users enter — these values reach your app and nowhere else.                                            |
+
+The parsed `payload` holds:
+
+| Field          | Description                                                                                                     |
+|:---------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`      | The format version of the payload, currently `1`. Compare it against `1` before parsing to guard against later changes. |
+| `element_id`   | The **Element ID** of the input or selectable group the value came from.                                        |
+| `element_type` | The type of element that sent the value. It tells you how to read `value`.                                      |
+| `value`        | What the user entered or selected. Its shape depends on `element_type`.                                         |
+
+<FlowInputValueTypes />
+
+## Event examples
+
+These examples show the properties available on each event, with illustrative values in comments.
+
+<Details>
+<summary>Text, email, number, and phone input (Click to expand)</summary>
+
+```javascript
+onAnalytics(name, params) {
+  name;                      // 'flow_user_input'
+  params.instanceId;         // 'scr_J260KU5q'
+  params.isCustomerEvent;    // true
+  params.isBackendEvent;     // false
+  params.payload;            // '{"version":1,"element_id":"email","element_type":"email_input","value":"jane@example.com"}'
+
+  // payload, once parsed:
+  input.version;             // 1
+  input.element_id;          // 'email'
+  input.element_type;        // 'email_input'
+  input.value;               // 'jane@example.com'   (string)
+}
+```
+</Details>
+
+<Details>
+<summary>Date, time, and date-time pickers (Click to expand)</summary>
+
+```javascript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'birthday'
+  input.element_type;  // 'date_picker'
+  input.value;         // 645408000000   (Unix milliseconds — 1990-06-15)
+}
+```
+</Details>
+
+<Details>
+<summary>Single choice (Click to expand)</summary>
+
+```javascript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'experience'
+  input.element_type;  // 'single_choice'
+  input.value;         // { id: 'pro', title: 'I train professionally' }
+}
+```
+</Details>
+
+<Details>
+<summary>Multi choice (Click to expand)</summary>
+
+```javascript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'interests'
+  input.element_type;  // 'multi_choice'
+  input.value;         // [{ id: 'sports', title: 'Sports' },
+                       //  { id: 'music',  title: 'Music' }]
+}
+```
+</Details>
+
+<Details>
+<summary>Toggle (Click to expand)</summary>
+
+```javascript
+onAnalytics(name, params) {
+  // payload, once parsed:
+  input.element_id;    // 'reminders'
+  input.element_type;  // 'toggle'
+  input.value;         // true   (boolean)
+}
+```
+</Details>
+
+## Delivery and limitations
+
+<FlowInputLimitations />
+
+The SDK tells you the flow closed through `onDisappeared`. Collect answers as they arrive and act on the full set there.
+
+## Use cases
+
+### Register users on your backend
+
+Collect values as they arrive and send them once the flow closes, so that one request carries a complete set of answers.
+
+The flow disappears whether a user finished it or abandoned it partway. Guard on the fields you need before you call your backend.
+
+```javascript showLineNumbers title="React Native"
+const flowAnswers = {};
+
+const unsubscribe = view.setEventHandlers({
+  onAnalytics(name, params) {
+    if (name === 'flow_user_input' && typeof params.payload === 'string') {
+      const input = JSON.parse(params.payload);
+      flowAnswers[input.element_id] = input.value;
+    }
+    return false;
+  },
+  onDisappeared() {
+    if (flowAnswers.email) {
+      // Send flowAnswers to your backend here to create the account.
+    }
+    return false;
+  },
+});
+```
+
+### Enrich user profiles with data
+
+To link what a user entered to their profile and avoid asking for the same details twice, [update the user profile](react-native-setting-user-attributes) as the values come in.
+
+For example, if your flow has a text input with the Element ID `name` and an email input with the Element ID `email`:
+
+```javascript showLineNumbers title="React Native"
+function handleFlowInput(name, params) {
+  if (name !== 'flow_user_input') return;
+  if (typeof params.payload !== 'string') return;
+
+  const input = JSON.parse(params.payload);
+  const profileParams = {};
+
+  switch (input.element_id) {
+    case 'name':
+      profileParams.firstName = input.value;
+      break;
+    case 'email':
+      profileParams.email = input.value;
+      break;
+    default:
+      return;
+  }
+
+  adapty.updateProfile(profileParams).catch(error => {
+    // handle the error
+  });
+}
+```
+
+### Customize flows shown later
+
+Quiz answers can also decide what a user sees at a later [placement](placements) — a different flow, or a different paywall inside it.
+
+For example, ask users about their experience with sport in your onboarding flow, then show each group its own flow with different products and copy.
+
+1. Add a [quiz](onboarding-quizzes) to your flow and give each option a meaningful [Element ID](flow-selectable-elements).
+2. Handle the answers and [set custom attributes](react-native-setting-user-attributes) for the user.
+
+```javascript showLineNumbers title="React Native"
+function handleFlowInput(name, params) {
+  if (name !== 'flow_user_input') return;
+  if (typeof params.payload !== 'string') return;
+
+  const input = JSON.parse(params.payload);
+  if (input.element_id !== 'experience') return;
+
+  adapty
+    .updateProfile({
+      // Set the custom attribute 'experience' to the option the user picked
+      // (beginner, amateur, or pro).
+      codableCustomAttributes: { experience: input.value.id },
+    })
+    .catch(error => {
+      // handle the error
+    });
+}
+```
+
+3. [Create a segment](segments) for each custom attribute value.
+4. Create a [placement](placements) and add an [audience](audience) for each segment.
+5. [Display the flow](react-native-present-paywalls) for that placement in your app.

--- a/src/content/docs/react-native/react-native-handling-events-1.mdx
+++ b/src/content/docs/react-native/react-native-handling-events-1.mdx
@@ -368,6 +368,8 @@ const unsubscribe = view.setEventHandlers({
 
 See [Track flow screen views](react-native-flow-screen-views) for what to do with them.
 
+A flow also reports the values users type and select. See [Process data from flows](react-native-flow-input) to read them.
+
 ### Handle purchases in observer mode
 
 If you activated the SDK in [Observer mode](implement-observer-mode-react-native) (`observerMode: true`) and present an Adapty-rendered flow, the SDK does not make purchases for you. When a user taps the purchase or restore button, the SDK invokes `onObserverPurchaseInitiated` or `onObserverRestoreInitiated` instead. Perform the purchase or restore with your own code, drive the flow's loading indicator with the provided callbacks, and [report the transaction](report-transactions-observer-mode-react-native) to Adapty afterwards.

--- a/src/content/docs/unity/unity-flow-input.mdx
+++ b/src/content/docs/unity/unity-flow-input.mdx
@@ -1,0 +1,305 @@
+---
+title: "Process data from flows in Unity SDK"
+description: "Save and use data your users enter in flows in your Unity app with Adapty SDK."
+metadataTitle: "Process data from flows | Unity SDK | Adapty Docs"
+---
+
+When a user types into an input field, answers a quiz, or flips a toggle in a [flow](adapty-flow-builder), the SDK passes the value to your app through its analytics callback.
+
+Apps most often use that data to:
+
+- **Register users on their own backend**: Take the email address and the name a user entered in your onboarding flow, and create their account without a second sign-up screen.
+- **Save answers and preferences**: Keep what a user picked so your app can act on it later, or [write it to their Adapty profile](unity-setting-user-attributes) as custom attributes.
+- **Customize the flows a user sees later**: Save quiz answers as custom attributes, then target a later placement so each segment gets a different flow, or a different paywall inside it.
+- **Feed your own analytics**: Forward answers to Amplitude, Mixpanel, or whichever product analytics you run.
+
+You don't set anything up in the builder — inputs and selectable groups report their values automatically.
+
+## Before you start
+
+You need:
+
+- **Adapty Unity SDK v4 or later**: The flow callbacks don't exist in earlier versions.
+- **A flow built in the [Flow Builder](adapty-flow-builder)**: Only flows report input values through this callback.
+- **A recently published flow version**: A flow reports input values only if you published it after this feature became available. If nothing reaches your listener, publish a new version of the flow and try again.
+
+## Receive input values
+
+Input values reach the same callback as every other analytics event from a flow, under the event name `flow_user_input`. Implement `FlowViewDidReceiveAnalyticEvent` on the listener you register with `Adapty.SetFlowsEventsListener`:
+
+```csharp showLineNumbers title="Unity"
+public void FlowViewDidReceiveAnalyticEvent(
+    AdaptyUIFlowView view,
+    string name,
+    IDictionary<string, object> @params
+) {
+    HandleFlowInput(name, @params);
+}
+```
+
+A flow reports other analytics events through this callback as well, such as screen views. Match on `name` before you read anything else, or your listener will run on events that carry no input. See [Handle flow & paywall events](unity-handling-events) for the rest of them.
+
+The `payload` entry is a JSON **string**, not a dictionary — parse it before you read the answer:
+
+```csharp showLineNumbers title="Unity"
+private void HandleFlowInput(string name, IDictionary<string, object> @params) {
+    if (name != "flow_user_input") return;
+    if (!(@params["payload"] is string payload)) return;
+
+    var input = JSON.Parse(payload);
+    var elementId = input["element_id"].Value;
+
+    // The screen the input sits on. Pair it with elementId to tell apart
+    // two fields that share an Element ID on different screens.
+    var screenId = @params["instanceId"] as string;
+
+    switch (input["element_type"].Value) {
+        case "text_input":
+        case "email_input":
+        case "number_input":
+        case "phone_input":
+            var text = input["value"].Value;
+            break;
+        case "date_picker":
+        case "time_picker":
+        case "date_time_picker":
+            var millis = input["value"].AsLong;
+            break;
+        case "single_choice":
+            var option = input["value"];
+            break;
+        case "multi_choice":
+            var options = input["value"].AsArray;
+            break;
+        case "toggle":
+            var isOn = input["value"].AsBool;
+            break;
+    }
+}
+```
+
+## What arrives in the callback
+
+| Parameter                    | Description                                                                                                                                                            |
+|:-----------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                       | The event name. Input values reach you as `flow_user_input`.                                                                                                           |
+| `@params["instanceId"]`      | The ID of the screen the input is on. An Element ID is unique within one screen but can repeat across screens, so use `instanceId` together with `element_id` to tell two fields apart. |
+| `@params["payload"]`         | A JSON string holding the answer. Parse it to read `element_id`, `element_type`, and `value`.                                                                          |
+| `@params["isCustomerEvent"]` | `true` for events meant for your own analytics.                                                                                                                        |
+| `@params["isBackendEvent"]`  | `false` for `flow_user_input`. Adapty doesn't receive or store what users enter — these values reach your app and nowhere else.                                        |
+
+The parsed `payload` holds:
+
+| Field          | Description                                                                                                     |
+|:---------------|:------------------------------------------------------------------------------------------------------------------|
+| `version`      | The format version of the payload, currently `1`. Compare it against `1` before parsing to guard against later changes. |
+| `element_id`   | The **Element ID** of the input or selectable group the value came from.                                        |
+| `element_type` | The type of element that sent the value. It tells you how to read `value`.                                      |
+| `value`        | What the user entered or selected. Its shape depends on `element_type`.                                         |
+
+<FlowInputValueTypes />
+
+## Event examples
+
+These examples show the properties available on each event, with illustrative values in comments.
+
+<Details>
+<summary>Text, email, number, and phone input (Click to expand)</summary>
+
+```csharp
+public void FlowViewDidReceiveAnalyticEvent(
+    AdaptyUIFlowView view,
+    string name,
+    IDictionary<string, object> @params
+) {
+    name;                            // "flow_user_input"
+    @params["instanceId"];           // "scr_J260KU5q"
+    @params["isCustomerEvent"];      // true
+    @params["isBackendEvent"];       // false
+    @params["payload"];              // "{\"version\":1,\"element_id\":\"email\",\"element_type\":\"email_input\",\"value\":\"jane@example.com\"}"
+
+    // payload, once parsed:
+    input["version"];                // 1
+    input["element_id"];             // "email"
+    input["element_type"];           // "email_input"
+    input["value"];                  // "jane@example.com"   (string)
+}
+```
+</Details>
+
+<Details>
+<summary>Date, time, and date-time pickers (Click to expand)</summary>
+
+```csharp
+public void FlowViewDidReceiveAnalyticEvent(
+    AdaptyUIFlowView view,
+    string name,
+    IDictionary<string, object> @params
+) {
+    // payload, once parsed:
+    input["element_id"];    // "birthday"
+    input["element_type"];  // "date_picker"
+    input["value"];         // 645408000000   (Unix milliseconds — 1990-06-15)
+}
+```
+</Details>
+
+<Details>
+<summary>Single choice (Click to expand)</summary>
+
+```csharp
+public void FlowViewDidReceiveAnalyticEvent(
+    AdaptyUIFlowView view,
+    string name,
+    IDictionary<string, object> @params
+) {
+    // payload, once parsed:
+    input["element_id"];    // "experience"
+    input["element_type"];  // "single_choice"
+    input["value"];         // {"id": "pro", "title": "I train professionally"}
+}
+```
+</Details>
+
+<Details>
+<summary>Multi choice (Click to expand)</summary>
+
+```csharp
+public void FlowViewDidReceiveAnalyticEvent(
+    AdaptyUIFlowView view,
+    string name,
+    IDictionary<string, object> @params
+) {
+    // payload, once parsed:
+    input["element_id"];    // "interests"
+    input["element_type"];  // "multi_choice"
+    input["value"];         // [{"id": "sports", "title": "Sports"},
+                            //  {"id": "music",  "title": "Music"}]
+}
+```
+</Details>
+
+<Details>
+<summary>Toggle (Click to expand)</summary>
+
+```csharp
+public void FlowViewDidReceiveAnalyticEvent(
+    AdaptyUIFlowView view,
+    string name,
+    IDictionary<string, object> @params
+) {
+    // payload, once parsed:
+    input["element_id"];    // "reminders"
+    input["element_type"];  // "toggle"
+    input["value"];         // true   (bool)
+}
+```
+</Details>
+
+## Delivery and limitations
+
+<FlowInputLimitations />
+
+The SDK tells you the flow closed through `FlowViewDidDisappear`. Collect answers as they arrive and act on the full set there.
+
+## Use cases
+
+### Register users on your backend
+
+Collect values as they arrive and send them once the flow closes, so that one request carries a complete set of answers.
+
+The view disappears whether a user finished the flow or abandoned it partway. Guard on the fields you need before you call your backend.
+
+```csharp showLineNumbers title="Unity"
+private readonly Dictionary<string, string> flowAnswers = new Dictionary<string, string>();
+
+public void FlowViewDidReceiveAnalyticEvent(
+    AdaptyUIFlowView view,
+    string name,
+    IDictionary<string, object> @params
+) {
+    if (name != "flow_user_input") return;
+    if (!(@params["payload"] is string payload)) return;
+
+    var input = JSON.Parse(payload);
+    flowAnswers[input["element_id"].Value] = input["value"].Value;
+}
+
+public void FlowViewDidDisappear(AdaptyUIFlowView view) {
+    if (!flowAnswers.ContainsKey("email")) return;
+
+    // Send flowAnswers to your backend here to create the account.
+
+    flowAnswers.Clear();
+}
+```
+
+### Enrich user profiles with data
+
+To link what a user entered to their profile and avoid asking for the same details twice, [update the user profile](unity-setting-user-attributes) as the values come in.
+
+For example, if your flow has a text input with the Element ID `name` and an email input with the Element ID `email`:
+
+```csharp showLineNumbers title="Unity"
+private void HandleFlowInput(string name, IDictionary<string, object> @params) {
+    if (name != "flow_user_input") return;
+    if (!(@params["payload"] is string payload)) return;
+
+    var input = JSON.Parse(payload);
+    var value = input["value"].Value;
+    var builder = new AdaptyProfileParameters.Builder();
+
+    switch (input["element_id"].Value) {
+        case "name":
+            builder = builder.SetFirstName(value);
+            break;
+        case "email":
+            builder = builder.SetEmail(value);
+            break;
+        default:
+            return;
+    }
+
+    Adapty.UpdateProfile(builder.Build(), (error) => {
+        if (error != null) {
+            // handle the error
+        }
+    });
+}
+```
+
+### Customize flows shown later
+
+Quiz answers can also decide what a user sees at a later [placement](placements) — a different flow, or a different paywall inside it.
+
+For example, ask users about their experience with sport in your onboarding flow, then show each group its own flow with different products and copy.
+
+1. Add a [quiz](onboarding-quizzes) to your flow and give each option a meaningful [Element ID](flow-selectable-elements).
+2. Handle the answers and [set custom attributes](unity-setting-user-attributes) for the user.
+
+```csharp showLineNumbers title="Unity"
+private void HandleFlowInput(string name, IDictionary<string, object> @params) {
+    if (name != "flow_user_input") return;
+    if (!(@params["payload"] is string payload)) return;
+
+    var input = JSON.Parse(payload);
+    if (input["element_id"].Value != "experience") return;
+
+    var optionId = input["value"]["id"].Value;
+
+    var builder = new AdaptyProfileParameters.Builder();
+    // Set the custom attribute 'experience' to the option the user picked
+    // (beginner, amateur, or pro).
+    builder = builder.SetCustomStringAttribute("experience", optionId);
+
+    Adapty.UpdateProfile(builder.Build(), (error) => {
+        if (error != null) {
+            // handle the error
+        }
+    });
+}
+```
+
+3. [Create a segment](segments) for each custom attribute value.
+4. Create a [placement](placements) and add an [audience](audience) for each segment.
+5. [Display the flow](unity-present-paywalls) for that placement in your app.

--- a/src/content/docs/unity/unity-handling-events.mdx
+++ b/src/content/docs/unity/unity-handling-events.mdx
@@ -452,6 +452,8 @@ public void FlowViewDidReceiveAnalyticEvent(
 
 See [Track flow screen views](unity-flow-screen-views) for what to do with them.
 
+A flow also reports the values users type and select. See [Process data from flows](unity-flow-input) to read them.
+
 ### Handle system requests
 
 The `IAdaptyUISystemRequestsHandler` (registered via `Adapty.SetSystemRequestsHandler(...)`) is reserved for system requests from a flow: OS permission prompts (such as push notifications or camera access) and app review requests. Flows don't trigger these requests yet, so you don't need to register a handler.

--- a/src/data/sidebars/android.json
+++ b/src/data/sidebars/android.json
@@ -76,6 +76,11 @@
         },
         {
           "type": "doc",
+          "label": "Process data from flows",
+          "id": "android-flow-input"
+        },
+        {
+          "type": "doc",
           "label": "Use fallbacks",
           "id": "android-use-fallback-paywalls"
         },

--- a/src/data/sidebars/capacitor.json
+++ b/src/data/sidebars/capacitor.json
@@ -83,6 +83,11 @@
       },
       {
         "type": "doc",
+        "label": "Process data from flows",
+        "id": "capacitor-flow-input"
+      },
+      {
+        "type": "doc",
         "id": "capacitor-use-fallback-paywalls",
         "label": "Use fallbacks"
       },

--- a/src/data/sidebars/flutter.json
+++ b/src/data/sidebars/flutter.json
@@ -76,6 +76,11 @@
       },
       {
         "type": "doc",
+        "label": "Process data from flows",
+        "id": "flutter-flow-input"
+      },
+      {
+        "type": "doc",
         "label": "Use fallbacks",
         "id": "flutter-use-fallback-paywalls"
       },

--- a/src/data/sidebars/ios.json
+++ b/src/data/sidebars/ios.json
@@ -76,6 +76,11 @@
       },
       {
         "type": "doc",
+        "label": "Process data from flows",
+        "id": "ios-flow-input"
+      },
+      {
+        "type": "doc",
         "label": "Use fallbacks",
         "id": "ios-use-fallback-paywalls"
       },

--- a/src/data/sidebars/kmp.json
+++ b/src/data/sidebars/kmp.json
@@ -83,6 +83,11 @@
       },
       {
         "type": "doc",
+        "label": "Process data from flows",
+        "id": "kmp-flow-input"
+      },
+      {
+        "type": "doc",
         "id": "kmp-use-fallback-paywalls",
         "label": "Use fallbacks"
       },

--- a/src/data/sidebars/react-native.json
+++ b/src/data/sidebars/react-native.json
@@ -88,6 +88,11 @@
         "id": "react-native-flow-screen-views"
       },
       {
+        "type": "doc",
+        "label": "Process data from flows",
+        "id": "react-native-flow-input"
+      },
+      {
         "type": "category",
         "label": "Use fallbacks",
         "collapsed": true,

--- a/src/data/sidebars/unity.json
+++ b/src/data/sidebars/unity.json
@@ -76,6 +76,11 @@
       },
       {
         "type": "doc",
+        "label": "Process data from flows",
+        "id": "unity-flow-input"
+      },
+      {
+        "type": "doc",
         "label": "Implement web paywalls",
         "id": "unity-web-paywalls"
       },


### PR DESCRIPTION
Flows report the values users type and select to the app through the SDK's analytics callback, as a `flow_user_input` event. This is the second half of the flow analytics work — screen views shipped separately and are already documented on main.

Rebased onto main after the screen-view guides merged, so this now carries only the user-input half: 23 files, additions only.

## New articles

"Process data from flows" for iOS, Android, Flutter, React Native, Capacitor, Unity, and Kotlin Multiplatform — added to each **Flows & paywalls** sidebar right after "Track screen views".

Each covers registering the callback, decoding the payload, the value shape per element type, delivery limitations, and three use cases: registering users on your own backend, enriching the Adapty profile, and segmenting which flow a user sees later.

Two shared reusables hold what is identical across platforms — the element-type/value table and the delivery limitations — so the contract has one home rather than seven. The payload is versioned (`version: 1`), so a v2 is expected.

Each handling-events article now points at its platform's guide, alongside the screen-view pointer already there.

## Per-platform differences worth review

These are the places a copy-paste sweep would have got wrong:

- **KMP decodes twice.** It receives the whole envelope as a raw JSON string, so `payload` is a JSON string nested inside one. Both steps are shown.
- **Capacitor wraps profile params** — `updateProfile({ params: … })` — where React Native passes the object directly.
- **Flutter and Unity order custom-attribute arguments oppositely**: `setCustomStringAttribute(value, key)` vs `SetCustomStringAttribute(key, value)`.

Every API name and signature was verified against the SDK source, not inferred.

## Why this is still a draft

The backend transformer change that emits `flow_user_input` is not merged, and product/privacy approval for sending raw text, email, and phone values to client code with no opt-out is still open. If that review adds an opt-out or trims which fields are sent, the "you don't set anything up in the builder" framing in all seven intros needs reworking. Please don't merge before the transformer ships.

Two things the docs say that reviewers should sanity-check:

- Flows published before this ships emit nothing until republished. Documented as a prerequisite, since it is the most likely "nothing is happening" report.
- `element_id` is not unique across screens; the key is `instanceId` + `element_id`.

## Verification

`check-mdx-parse` clean across 5,970 files, `lint-mdx` OK, `check-links --diff` 0 broken and 0 stale over 233 links. Every sidebar entry checked to resolve to a real file.
