### PR TITLE
docs: fix RevenueCat CSV export step in migration plan

### DIFF
--- a/src/content/docs/version-3.0/migration-from-revenuecat.mdx
+++ b/src/content/docs/version-3.0/migration-from-revenuecat.mdx
@@ -14,7 +14,7 @@ Your migration plan will have 5 logical steps and take an average of 2 hours. 90
 2. Install Adapty SDK for your platform ([iOS](sdk-installation-ios), [Android](sdk-installation-android), [React Native](sdk-installation-reactnative), [Flutter](sdk-installation-flutter), [Kotlin Multiplatform](sdk-installation-kotlin-multiplatform), [Unity](sdk-installation-unity)) instead of RevenueCat SDK _(1 hour)_;
 3. Set up [Apple App Store server notifications](enable-app-store-server-notifications) to Adapty and (optionally) [raw events forwarding](enable-app-store-server-notifications#raw-events-forwarding) _(5 minutes)_;
 4. Test and release updates of your app _(30 minutes);_
-5. (Optional) Ask RevenueCat support for historical data in CSV format  _(5 minutes);_
+5. (Optional) Export your RevenueCat historical data in CSV format using [RevenueCat’s scheduled data exports](https://www.revenuecat.com/docs/integrations/scheduled-data-exports) _(5 minutes);_
 6. (Optional) Import historical data via Adapty support _(30 minutes)_.
 
 :::info
@@ -133,7 +133,7 @@ Go through [release checklist](release-checklist).
 Make the final check using our list to validate the existing integration or add additional features such as [attribution](attribution-integration) or [analytics](analytics-integration) integrations.
 :::
 
-## (Optional) Export your RevenueCat historical data  in CSV format
+## (Optional) Export your RevenueCat historical data in CSV format
 
 :::warning
 Don't rush the historical data import


### PR DESCRIPTION
Step 5 of the migration plan said to *ask RevenueCat support* for historical data in CSV format, but the section it points to describes exporting it yourself via RevenueCat's scheduled data exports. Contacting RevenueCat support is only needed for Google Purchase Tokens, which is already a separate step further down the page.

Changes:

- Step 5 now matches its section and links directly to [RevenueCat's scheduled data exports doc](https://www.revenuecat.com/docs/integrations/scheduled-data-exports).
- Removed a stray double space in the section heading, which produced a double dash in the generated anchor (`...historical-data--in-csv-format`). Nothing in `src/content/` or the sidebars linked to the old anchor, and the translated files under `src/locales/` already carry the single-dash version — so this brings the English page into alignment with them.

`check-mdx-parse` and `lint-mdx` both pass.