### PR TITLE
Teach the new plugin and skill names for the Adapty skills repo

### DIFF
--- a/.claude/context-mill/zones/agent-tooling.md
+++ b/.claude/context-mill/zones/agent-tooling.md
@@ -43,7 +43,7 @@ Unusual for this corpus: half of what this zone asserts is owned by two Adapty r
   TODO(owner): is the env-var token path deliberately undocumented — a CI/headless story we don't
   support yet — or a gap in `developer-cli-authentication`?
 - **The skill — `adapty-sdk-integration-skill`, `origin/main`. Also not in `sources.md`.** Content is
-  `skills/adapty-sdk-integration/SKILL.md` plus `references/<platform>.md`. It is not generated from the
+  `skills/adapty-integration/SKILL.md` plus `references/<platform>.md`. It is not generated from the
   SDKs: it is **pinned to our published docs**, and `scripts/lint-symbols.mjs` says so in its own header
   ("the docs are verified against SDK sources by the docs team's own release process, so 'symbol appears
   in the docs' transitively means 'symbol exists in the SDK'. This lint closes the remaining gap:
@@ -102,7 +102,7 @@ The delta that matters here is that most of the surface belongs to someone else 
 on one side, a non-deterministic agent on the other.
 
 - **We document what to hand the tool and in what order; we never document the tool's own UI.** An
-  install command, the `/adapty-sdk-integration` invocation, and "use plan mode if your tool has one"
+  install command, the `/adapty-integration` invocation, and "use plan mode if your tool has one"
   are in scope. A walkthrough of Cursor's settings, an editor screenshot, or an MCP config file is not —
   it belongs to someone else's release schedule, and per `scope.md` the reader can see it anyway.
   Confirmed as current practice: `adapty-cursor` mentions plan mode in a single clause and delegates
@@ -211,7 +211,7 @@ Corpus-wide synonyms live in `aliases.md` and are not repeated here.
 | How a ticket says it | Where it actually lives |
 |---|---|
 | "vibe code the integration", "have Cursor/Claude add Adapty to my app", "AI pair-programming for IAP" | Two competing families, and `manage-adapty-with-ai` is the router between them: `adapty-sdk-integration-skill*` = one command, the agent drives the whole thing; `adapty-cursor*` = staged walkthrough where the developer feeds docs and reviews each step. Pick by how much control the reader wants, not by tool. |
-| "which skill do I install", "the skill didn't set up my app/products" | Three *different* skills, easily conflated. `adapty-sdk-integration` (own repo, marketplace/`gh skill`/`npx skills` install) does the full app-code integration. The `adapty-cli` skill only drives dashboard entities through the CLI — it's linked from `developer-cli`, `developer-cli-quickstart`, `developer-cli-authentication`, and from the dashboard-setup step of every `adapty-cursor*`. The third, adapty-cli-setup (ships in the apple-ads-cli plugin), only installs and authenticates the CLI in agent sessions — `developer-cli-cowork` is the article that has readers install it. |
+| "which skill do I install", "the skill didn't set up my app/products" | Three *different* skills, easily conflated. `adapty-integration` (own repo, marketplace/`gh skill`/`npx skills` install) does the full app-code integration. The `adapty-cli` skill only drives dashboard entities through the CLI — it's linked from `developer-cli`, `developer-cli-quickstart`, `developer-cli-authentication`, and from the dashboard-setup step of every `adapty-cursor*`. The third, adapty-cli-setup (ships in the apple-ads-cli plugin), only installs and authenticates the CLI in agent sessions — `developer-cli-cowork` is the article that has readers install it. |
 | "the skill stalled", "the agent went off the rails halfway" | The `adapty-sdk-integration-skill*` pages. The skill is beta and the documented fallback is the matching `adapty-cursor*` guide — that redirect is the answer, not a bug report. |
 | "which key does my agent need", "agent got 401", "where's the API key" | The single commonest confusion in this zone, and it splits three ways. SDK integration (`adapty-cursor*`, `adapty-sdk-integration-skill*`) = **public SDK key**, passed to `activate`. Analytics and backend guides (`export-analytics-with-ai`, `server-side-api-with-ai`) = **secret app-specific key**, and note the base URLs differ (`api-admin.adapty.io` for analytics vs `api.adapty.io` for server-side). The CLI (`developer-cli-authentication`) uses **no key at all** — browser device-code login. **Refined 2026-08-11 against `adapty-cli` `origin/main`:** the docs describe only the device-code path, but the CLI checks `ADAPTY_TOKEN` in the environment *before* it reads the config file, and the config location is oclif's `configDir` (`~/.config/adapty/config.json` by default on darwin, overridable via `XDG_CONFIG_HOME`), not a fixed path. So "no key at all" is true of the documented flow and false of the tool — a reader debugging a 401 in CI needs the env-var branch, which no article mentions. |
 | "MCP server for Adapty", "connect Adapty to my agent via MCP" | `manage-adapty-with-ai`. There is no first-party Adapty MCP server. Context7 is third-party and indexes only code snippets, not prose; the CLI is the "agent can actually act" path; analytics needs only a fetch-capable tool. |

--- a/scripts/context-mill/briefs.mjs
+++ b/scripts/context-mill/briefs.mjs
@@ -203,7 +203,9 @@ const MARKUP_WORDS = new Set([
   // Plural concepts that read like ids but name no article.
   'flows', 'audiences', 'beta',
   // External package and skill-repo names, not articles in this corpus.
-  'adapty-cli', 'adapty-sdk-integration', 'expo-secure-store',
+  // 'adapty-sdk-integration' is the pre-rename name, still named in archived
+  // release notes; keep both so neither reads as an article id.
+  'adapty-cli', 'adapty-integration', 'adapty-sdk-integration', 'expo-secure-store',
 ]);
 
 export function referencedArticleIds(text) {

--- a/scripts/generate-md.mjs
+++ b/scripts/generate-md.mjs
@@ -149,7 +149,7 @@ ${content}
     // Replace <SkillPromo ... /> with a plain-text promo + a markdown link to the skill repo
     processed = processed.replace(
         /<SkillPromo\b[^>]*\/>/g,
-        'For a fully automated integration, use the [adapty-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill): it runs the whole integration from your AI coding tool in one command.'
+        'For a fully automated integration, use the [adapty-integration skill](https://github.com/adaptyteam/adapty-skills): it runs the whole integration from your AI coding tool in one command.'
     );
 
     // Convert <ProductMap /> into a proper markdown table. The component is

--- a/scripts/generate-md.mjs
+++ b/scripts/generate-md.mjs
@@ -149,7 +149,7 @@ ${content}
     // Replace <SkillPromo ... /> with a plain-text promo + a markdown link to the skill repo
     processed = processed.replace(
         /<SkillPromo\b[^>]*\/>/g,
-        'For a fully automated integration, use the [adapty-sdk-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill): it runs the whole integration from your AI coding tool in one command.'
+        'For a fully automated integration, use the [adapty-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill): it runs the whole integration from your AI coding tool in one command.'
     );
 
     // Convert <ProductMap /> into a proper markdown table. The component is

--- a/scripts/generate-platform-llms-full.mjs
+++ b/scripts/generate-platform-llms-full.mjs
@@ -112,7 +112,7 @@ function stripContent(content, reusableComponents) {
     // Replace <SkillPromo ... /> with a plain-text promo + a markdown link to the skill repo
     processed = processed.replace(
         /<SkillPromo\b[^>]*\/>/g,
-        'For a fully automated integration, use the [adapty-sdk-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill): it runs the whole integration from your AI coding tool in one command.'
+        'For a fully automated integration, use the [adapty-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill): it runs the whole integration from your AI coding tool in one command.'
     );
 
     // 3. Inline Reusable Components

--- a/scripts/generate-platform-llms-full.mjs
+++ b/scripts/generate-platform-llms-full.mjs
@@ -112,7 +112,7 @@ function stripContent(content, reusableComponents) {
     // Replace <SkillPromo ... /> with a plain-text promo + a markdown link to the skill repo
     processed = processed.replace(
         /<SkillPromo\b[^>]*\/>/g,
-        'For a fully automated integration, use the [adapty-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill): it runs the whole integration from your AI coding tool in one command.'
+        'For a fully automated integration, use the [adapty-integration skill](https://github.com/adaptyteam/adapty-skills): it runs the whole integration from your AI coding tool in one command.'
     );
 
     // 3. Inline Reusable Components

--- a/src/components/reusable/AdaptySdkIntegrationSkill.mdx
+++ b/src/components/reusable/AdaptySdkIntegrationSkill.mdx
@@ -2,19 +2,19 @@
 no_index: true
 ---
 
-The [adapty-sdk-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill) automates Adapty integration end to end: dashboard setup, SDK install, paywall, and per-stage verification. It detects your platform automatically and fetches the relevant Adapty docs at each stage.
+The [adapty-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill) automates Adapty integration end to end: dashboard setup, SDK install, paywall, and per-stage verification. It detects your platform automatically and fetches the relevant Adapty docs at each stage.
 
 **Supported tools**: Claude Code, GitHub Copilot CLI, OpenAI Codex, Gemini CLI.
 
 To install, pick the form for your tool. The full list is in the [skill README](https://github.com/adaptyteam/adapty-sdk-integration-skill).
 
-The repository holds two skills — `adapty-sdk-integration` and `ads-manager`, which runs Apple Search Ads through the Adapty CLI. Each command below installs both.
+The repository holds two skills — `adapty-integration` and `ads-manager`, which runs Apple Search Ads through the Adapty CLI. Each command below installs both.
 
 **Claude Code**
 
 ```
 claude plugin marketplace add adaptyteam/adapty-sdk-integration-skill
-claude plugin install adapty-sdk-integration@adapty
+claude plugin install adapty-skills@adapty
 ```
 
 **GitHub Copilot CLI**
@@ -43,7 +43,7 @@ Alternatively, clone the repo and copy the directories under `skills/` into your
 After installing, run the skill in your project:
 
 ```
-/adapty-sdk-integration
+/adapty-integration
 ```
 
 The skill asks a few setup questions, then walks through dashboard setup, SDK install, paywall, and verification.

--- a/src/components/reusable/AdaptySdkIntegrationSkill.mdx
+++ b/src/components/reusable/AdaptySdkIntegrationSkill.mdx
@@ -2,38 +2,38 @@
 no_index: true
 ---
 
-The [adapty-integration skill](https://github.com/adaptyteam/adapty-sdk-integration-skill) automates Adapty integration end to end: dashboard setup, SDK install, paywall, and per-stage verification. It detects your platform automatically and fetches the relevant Adapty docs at each stage.
+The [adapty-integration skill](https://github.com/adaptyteam/adapty-skills) automates Adapty integration end to end: dashboard setup, SDK install, paywall, and per-stage verification. It detects your platform automatically and fetches the relevant Adapty docs at each stage.
 
 **Supported tools**: Claude Code, GitHub Copilot CLI, OpenAI Codex, Gemini CLI.
 
-To install, pick the form for your tool. The full list is in the [skill README](https://github.com/adaptyteam/adapty-sdk-integration-skill).
+To install, pick the form for your tool. The full list is in the [skill README](https://github.com/adaptyteam/adapty-skills).
 
 The repository holds two skills — `adapty-integration` and `ads-manager`, which runs Apple Search Ads through the Adapty CLI. Each command below installs both.
 
 **Claude Code**
 
 ```
-claude plugin marketplace add adaptyteam/adapty-sdk-integration-skill
+claude plugin marketplace add adaptyteam/adapty-skills
 claude plugin install adapty-skills@adapty
 ```
 
 **GitHub Copilot CLI**
 
 ```
-git clone https://github.com/adaptyteam/adapty-sdk-integration-skill.git
+git clone https://github.com/adaptyteam/adapty-skills.git
 cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/
 ```
 
 **Gemini CLI**
 
 ```
-gemini skills install https://github.com/adaptyteam/adapty-sdk-integration-skill
+gemini skills install https://github.com/adaptyteam/adapty-skills
 ```
 
 **OpenAI Codex or any other tool** — use the [skills CLI](https://skills.sh) (note that skills installed this way don't update automatically):
 
 ```
-npx skills add adaptyteam/adapty-sdk-integration-skill --all
+npx skills add adaptyteam/adapty-skills --all
 ```
 
 `--all` installs both skills into every agent it detects. Without it, the CLI asks which of the two you want.

--- a/src/content/docs/android/adapty-sdk-integration-skill-android.mdx
+++ b/src/content/docs/android/adapty-sdk-integration-skill-android.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Adapty into your Android app with the SDK integration skill"
-description: "Use the adapty-sdk-integration skill to integrate the Adapty SDK into your Android app end to end with your AI coding tool."
+description: "Use the adapty-integration skill to integrate the Adapty SDK into your Android app end to end with your AI coding tool."
 metadataTitle: "Integrate Adapty with the SDK Integration Skill for Android | Adapty Docs"
 ---
 

--- a/src/content/docs/capacitor/adapty-sdk-integration-skill-capacitor.mdx
+++ b/src/content/docs/capacitor/adapty-sdk-integration-skill-capacitor.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Adapty into your Capacitor app with the SDK integration skill"
-description: "Use the adapty-sdk-integration skill to integrate the Adapty SDK into your Capacitor app end to end with your AI coding tool."
+description: "Use the adapty-integration skill to integrate the Adapty SDK into your Capacitor app end to end with your AI coding tool."
 metadataTitle: "Integrate Adapty with the SDK Integration Skill for Capacitor | Adapty Docs"
 ---
 

--- a/src/content/docs/flutter/adapty-sdk-integration-skill-flutter.mdx
+++ b/src/content/docs/flutter/adapty-sdk-integration-skill-flutter.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Adapty into your Flutter app with the SDK integration skill"
-description: "Use the adapty-sdk-integration skill to integrate the Adapty SDK into your Flutter app end to end with your AI coding tool."
+description: "Use the adapty-integration skill to integrate the Adapty SDK into your Flutter app end to end with your AI coding tool."
 metadataTitle: "Integrate Adapty with the SDK Integration Skill for Flutter | Adapty Docs"
 ---
 

--- a/src/content/docs/ios/adapty-sdk-integration-skill.mdx
+++ b/src/content/docs/ios/adapty-sdk-integration-skill.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Adapty into your iOS app with the SDK integration skill"
-description: "Use the adapty-sdk-integration skill to integrate the Adapty SDK into your iOS app end to end with your AI coding tool."
+description: "Use the adapty-integration skill to integrate the Adapty SDK into your iOS app end to end with your AI coding tool."
 metadataTitle: "Integrate Adapty with the SDK Integration Skill for iOS | Adapty Docs"
 ---
 

--- a/src/content/docs/kmp/adapty-sdk-integration-skill-kmp.mdx
+++ b/src/content/docs/kmp/adapty-sdk-integration-skill-kmp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Adapty into your Kotlin Multiplatform app with the SDK integration skill"
-description: "Use the adapty-sdk-integration skill to integrate the Adapty SDK into your Kotlin Multiplatform app end to end with your AI coding tool."
+description: "Use the adapty-integration skill to integrate the Adapty SDK into your Kotlin Multiplatform app end to end with your AI coding tool."
 metadataTitle: "Integrate Adapty with the SDK Integration Skill for Kotlin Multiplatform | Adapty Docs"
 ---
 

--- a/src/content/docs/react-native/adapty-sdk-integration-skill-react-native.mdx
+++ b/src/content/docs/react-native/adapty-sdk-integration-skill-react-native.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Adapty into your React Native app with the SDK integration skill"
-description: "Use the adapty-sdk-integration skill to integrate the Adapty SDK into your React Native app end to end with your AI coding tool."
+description: "Use the adapty-integration skill to integrate the Adapty SDK into your React Native app end to end with your AI coding tool."
 metadataTitle: "Integrate Adapty with the SDK Integration Skill for React Native | Adapty Docs"
 ---
 

--- a/src/content/docs/unity/adapty-sdk-integration-skill-unity.mdx
+++ b/src/content/docs/unity/adapty-sdk-integration-skill-unity.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Adapty into your Unity app with the SDK integration skill"
-description: "Use the adapty-sdk-integration skill to integrate the Adapty SDK into your Unity app end to end with your AI coding tool."
+description: "Use the adapty-integration skill to integrate the Adapty SDK into your Unity app end to end with your AI coding tool."
 metadataTitle: "Integrate Adapty with the SDK Integration Skill for Unity | Adapty Docs"
 ---
 

--- a/src/data/agent-tools.json
+++ b/src/data/agent-tools.json
@@ -5,7 +5,7 @@
             "id": "claude-code",
             "label": "Claude Code",
             "commands": [
-                "claude plugin marketplace add adaptyteam/adapty-sdk-integration-skill",
+                "claude plugin marketplace add adaptyteam/adapty-skills",
                 "claude plugin install adapty-skills@adapty"
             ]
         },
@@ -13,7 +13,7 @@
             "id": "copilot-cli",
             "label": "Copilot CLI",
             "commands": [
-                "git clone https://github.com/adaptyteam/adapty-sdk-integration-skill.git",
+                "git clone https://github.com/adaptyteam/adapty-skills.git",
                 "cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/"
             ]
         },
@@ -21,14 +21,14 @@
             "id": "gemini-cli",
             "label": "Gemini CLI",
             "commands": [
-                "gemini skills install https://github.com/adaptyteam/adapty-sdk-integration-skill"
+                "gemini skills install https://github.com/adaptyteam/adapty-skills"
             ]
         },
         {
             "id": "codex",
             "label": "Codex",
             "commands": [
-                "git clone https://github.com/adaptyteam/adapty-sdk-integration-skill.git",
+                "git clone https://github.com/adaptyteam/adapty-skills.git",
                 "cp -r adapty-sdk-integration-skill/skills/* ~/.agents/skills/"
             ]
         },
@@ -37,7 +37,7 @@
             "label": "Any tool",
             "note": "anyToolNote",
             "commands": [
-                "npx skills add adaptyteam/adapty-sdk-integration-skill --all"
+                "npx skills add adaptyteam/adapty-skills --all"
             ]
         }
     ],

--- a/src/data/agent-tools.json
+++ b/src/data/agent-tools.json
@@ -1,12 +1,12 @@
 {
-    "usageCommand": "/adapty-sdk-integration",
+    "usageCommand": "/adapty-integration",
     "tools": [
         {
             "id": "claude-code",
             "label": "Claude Code",
             "commands": [
                 "claude plugin marketplace add adaptyteam/adapty-sdk-integration-skill",
-                "claude plugin install adapty-sdk-integration@adapty"
+                "claude plugin install adapty-skills@adapty"
             ]
         },
         {


### PR DESCRIPTION
## What

The Claude Code plugin is now **`adapty-skills`** and the SDK skill is **`adapty-integration`** (adaptyteam/adapty-sdk-integration-skill#35). This updates what the docs tell readers to type:

- `AdaptySdkIntegrationSkill.mdx` — install command, `/adapty-integration` invocation, and the two prose mentions
- `agent-tools.json` — `usageCommand` and the Claude Code install command
- 7 platform page descriptions — "the adapty-integration skill"
- `generate-md.mjs` + `generate-platform-llms-full.mjs` — the injected "use the … skill" sentence
- `briefs.mjs` — keeps **both** names in the non-article denylist
- `.claude/context-mill/zones/agent-tooling.md` — internal agent notes

## What is deliberately NOT changed

**Page slugs and repo URLs.** `adapty-sdk-integration-skill*` page ids stay — those are published URLs. The GitHub repo is not being renamed either, so every `adaptyteam/adapty-sdk-integration-skill` link is correct as-is. The substitution was boundary-aware and the diff contains zero `adapty-integration-skill` strings; please spot-check that.

**Locales.** The 7 locale copies carry the same strings, but their `.hashes` caches embed translated content keyed to the source `fileHash`. This change invalidates them, so the translation pipeline should regenerate them. I did not hand-edit translations — flagging in case the pipeline needs a nudge, and note the install-command line is language-independent if you'd rather patch it directly.

**`whats-new.mdx`.** A dated release note recording what was announced at the time; archival accuracy over findability. Say the word if you'd rather it point at the current name.

## Timing

Nothing here is urgent or breaking: the old plugin handle still resolves via a deprecated marketplace entry, so the current docs are stale rather than wrong. Merge whenever. The alias on the other side will only be dropped after this lands.

---

## ⛔ BLOCKED until the repo is renamed

These commits assume the GitHub repo has been renamed **`adaptyteam/adapty-sdk-integration-skill` → `adaptyteam/adapty-skills`**. That rename has **not happened yet**. Every updated URL here 404s until it does, so do not merge before the rename.

Rename steps (repo Settings → General → Repository name), then in whatever order:

1. Rename the repo on GitHub. Open PRs, branches and stars move with it; git and web traffic redirect from the old name indefinitely.
2. **Never create anything at `adaptyteam/adapty-sdk-integration-skill` again** — reusing the name permanently kills the redirect.
3. Re-register the **skills.sh** listing and the **Context7** entry — both key on `owner/repo`, and the old slugs remain as stale duplicates that cannot be redirected.
4. Merge adaptyteam/adapty-cli#17 **after** the skills-repo PR. `RAW_BASE` is a `raw.githubusercontent.com` URL and raw does **not** follow repo renames.

What survives the rename with no action: existing `claude plugin` installs (git remotes follow the redirect), existing clones, and every published docs page slug — `adapty-sdk-integration-skill*` page ids are unrelated to the repo name and deliberately unchanged.
