### PR TITLE
docs: document how per-period product prices are calculated

### DIFF
--- a/src/content/docs/version-3.0/onboarding-variables.mdx
+++ b/src/content/docs/version-3.0/onboarding-variables.mdx
@@ -57,16 +57,24 @@ Product variables pull localized data directly from the app stores. Use them in 
 | :--- | :--- | :--- |
 | `prod_title` | Localized title of the product | Premium Subscription |
 | `prod_price` | Localized price for one billing period | $9.99 |
-| `prod_price_per_day` | Subscription price divided by days in the billing period. Empty for non-subscriptions. | $0.33 |
-| `prod_price_per_week` | Subscription price divided by weeks in the billing period. Empty for non-subscriptions. | $2.33 |
-| `prod_price_per_month` | Subscription price adjusted to one month. Empty for non-subscriptions. | $9.99 |
-| `prod_price_per_year` | Subscription price adjusted to one year. Empty for non-subscriptions. | $119.88 |
+| `prod_price_per_day` | Subscription price converted to one day. Empty for non-subscriptions. | $0.33 |
+| `prod_price_per_week` | Subscription price converted to one week. Empty for non-subscriptions. | $2.33 |
+| `prod_price_per_month` | Subscription price converted to one month. Empty for non-subscriptions. | $9.99 |
+| `prod_price_per_year` | Subscription price converted to one year. Empty for non-subscriptions. | $119.88 |
 | `offer_price` | Localized price of an intro or promo offer. Empty if the user is not eligible for any offer. | $0.99 |
 | `offer_billing_period` | Localized billing period of an offer. Same as `offer_full_duration` for trial and pay-upfront offers. Empty if the user is not eligible. | 1 week |
 | `offer_full_duration` | Localized full duration of an offer. Empty if the user is not eligible. | 1 month |
 | `is_free_trial` | Returns `true` if the user is eligible for an offer with a free trial. | true |
 | `is_pay_up_front` | Returns `true` if the user is eligible for a pay-up-front offer. | true |
 | `is_pay_as_you_go` | Returns `true` if the user is eligible for a pay-as-you-go offer. | true |
+
+The `prod_price_per_*` variables convert the price from the product's billing period into the period you ask for. The conversion uses fixed period lengths, not calendar dates:
+
+- 1 week = 7 days
+- 1 month = 30 days
+- 1 year = 12 months, or 365 days
+
+For a $59.99 monthly subscription, `prod_price_per_week` returns $14.00: $59.99 × 7 ÷ 30 = $13.9977, rounded for display. A month is 30 / 7 ≈ 4.2857 weeks, so multiplying the weekly value by 4 doesn't return the original price.
 
 :::tip
 Use `is_free_trial`, `is_pay_up_front`, and `is_pay_as_you_go` with conditional visibility to show or hide elements based on the offer a user is eligible for. For example, show a free-trial timeline only when `is_free_trial` is `true`.


### PR DESCRIPTION
## What

Documents the period-length normalization behind the `prod_price_per_*` flow variables in the **Product variables** section of the Variables article.

- States the fixed period lengths the conversion uses: 1 week = 7 days, 1 month = 30 days, 1 year = 12 months or 365 days.
- Adds a worked example: a $59.99 monthly subscription renders `prod_price_per_week` as $14.00 ($59.99 × 7 ÷ 30 = $13.9977, rounded for display).
- Notes that a month is 30/7 ≈ 4.2857 weeks, so multiplying the weekly value by 4 doesn't return the original price.
- Normalizes the four table rows to "Subscription price converted to one day/week/month/year", replacing "divided by weeks in the billing period", which left the week count unknowable.

## Why

A customer upgrading to SDK 4.1.0 saw `PROD_PRICE_PER_WEEK` drop from $15.00 to $14.00 on a $59.99 monthly product and filed it as a pricing bug. The behavior is correct — a month normalizes to 30 days, not 4 weeks — but nothing in the docs said so, and the natural reverse-check (weekly value × 4) makes the price look discounted.

## Verification

Constants checked against SDK source rather than inferred:

- iOS 4.x — `Sources.AdaptyUI/Extensions/AdaptyProductSubscriptionPeriod+Extensions.swift`: `numberOfWeeks` returns `numberOfUnits * (30.0 / 7.0)` for months; `numberOfDays` uses 7/30/365.
- Android 4.x — `adapty-ui/.../text/PriceConverter.kt`: `toWeekly` for `MONTH` computes `amount × 7 / (30 × n)`. Same basis, so no per-platform qualifier is needed.

`check-mdx-parse`, `lint-mdx`, `lint-prose`, and `check-links-diff` all pass.

## Known gap

Year → week uses 52 weeks (364 days) rather than 365 ÷ 7, so a yearly product's `prod_price_per_week` reads ~0.3% higher than the stated lengths imply. Left as is — too small to be worth a caveat in the bullet list.

## Follow-ups (not in this PR)

- `offer_price_per_day/week/month/year` exist in both 4.x SDKs but are absent from the variables table.
- `paywall-builder-tag-variables.mdx` still documents the pre-4.0 4-week month for `<PROD_PRICE_PER_WEEK/>`. It sits in no sidebar, but it is the page the customer found by search.