### PR TITLE
docs: fix Google Play offer, Billing Library, and subscription-update guidance

### DIFF
--- a/src/content/docs/android/android-making-purchases.mdx
+++ b/src/content/docs/android/android-making-purchases.mdx
@@ -118,6 +118,10 @@ When a user opts for a new subscription instead of renewing the current one, the
 
 To replace the subscription with another one in Android, call `.makePurchase()` method with the additional parameter:
 
+:::warning
+Pass `subscriptionUpdateParams` only when the user switches from an active subscription purchased on the same Google account. For a new purchase, call `makePurchase` without this parameter — passing it makes the purchase fail with the `CURRENT_SUBSCRIPTION_TO_UPDATE_NOT_FOUND_IN_HISTORY` error, whose message misleadingly points to an inactive subscription or a different Google account.
+:::
+
 <Tabs groupId="current-os" queryString>
 <TabItem value="kotlin" label="Kotlin" default>
 ```kotlin showLineNumbers

--- a/src/content/docs/capacitor/sdk-installation-capacitor.mdx
+++ b/src/content/docs/capacitor/sdk-installation-capacitor.mdx
@@ -36,7 +36,7 @@ Capacitor versions 6 and below are not supported.
 Building for iOS with Adapty SDK v4 (beta) requires **Xcode 26** or later — the native iOS SDK it uses is built with Swift tools 6.2. The iOS 15.0+, Capacitor 8, and Android minSdk 24 requirements are the same as for SDK 3.16+.
 
 :::info
-Starting from SDK v3.17, Adapty SDK uses Google Play Billing Library v8.0.0 by default.
+Adapty Capacitor SDK 4.0.2 and later works with Google Play Billing Library v8.
 
 Compatibility with a Billing Library version doesn't mean Adapty supports every feature Google introduced in it. Before you adopt a new Google Play billing capability, see [Product in Play Store](android-products).
 :::

--- a/src/content/docs/unity/sdk-installation-unity.mdx
+++ b/src/content/docs/unity/sdk-installation-unity.mdx
@@ -30,7 +30,7 @@ Want to see a real-world example of how Adapty SDK is integrated into a mobile a
 Adapty SDK supports iOS 13.0+, but requires iOS 15.0+ to work with paywalls created in the paywall builder. Adapty SDK 4.0 (beta) — which adds [Flow Builder](adapty-flow-builder) support — requires **iOS 15.0+** for the whole app: a build validator in the Unity Editor stops the iOS build if the deployment target is lower.
 
 :::info
-Adapty is compatible with Google Play Billing Library up to 8.x. By default, Adapty uses Google Play Billing Library v7.0.0. To use a newer version, [override the Billing dependency](https://developer.android.com/google/play/billing/integrate#dependency) in your Android build.
+Adapty Unity SDK 4.0 and later works with Google Play Billing Library v8.
 
 Compatibility with a Billing Library version doesn't mean Adapty supports every feature Google introduced in it. Before you adopt a new Google Play billing capability, see [Product in Play Store](android-products).
 :::

--- a/src/content/docs/version-3.0/add-product-to-paywall.mdx
+++ b/src/content/docs/version-3.0/add-product-to-paywall.mdx
@@ -10,7 +10,7 @@ import 'react-medium-image-zoom/dist/styles.css';
 To make a product visible and selectable within a [paywall](paywalls) for your app's users, follow these steps:
 
 1. While [configuring a paywall](create-paywall), click **Add product** under the **Products** title.
-2. From the opened drop-down list, select the products that will be shown to your customers. The list contains only previously created products. The order of the products is preserved on the SDK side, so it's important to consider the desired order when configuring the paywall. Additionally, you can specify an offer for a product if desired.
+2. From the opened drop-down list, select the products that will be shown to your customers. The list contains only previously created products. The order of the products is preserved on the SDK side, so it's important to consider the desired order when configuring the paywall. Additionally, you can select an offer for a product. On Google Play, the offer you select here is the one applied at purchase: if you don't select an offer, users are charged the full base plan price without a trial or intro price, even if the offer is active in Google Play Console.
 
 <Zoom>
   <img src="/assets/shared/img/0479b51-ad_product_to_paywall.webp"

--- a/src/content/docs/version-3.0/sdk-installation-android.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-android.mdx
@@ -26,7 +26,7 @@ Want to see a real-world example of how Adapty SDK is integrated into a mobile a
 Minimum SDK requirement: `minSdkVersion 21`
 
 :::info
-By default, Adapty SDK 4.0.2 and later works with Google Play Billing Library v8. Earlier SDK versions work with v7.0.0 by default and are compatible with the Billing Library up to 8.x — to force a later version, manually [add the dependency](https://developer.android.com/google/play/billing/integrate#dependency).
+Adapty SDK 4.0.2 and later works with Google Play Billing Library v8.
 
 Compatibility with a Billing Library version doesn't mean Adapty supports every feature Google introduced in it. Before you adopt a new Google Play billing capability, see [Product in Play Store](android-products).
 :::

--- a/src/content/docs/version-3.0/sdk-installation-flutter.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-flutter.mdx
@@ -30,7 +30,7 @@ Adapty SDK supports iOS 13.0+, but requires iOS 15.0+ to work properly with payw
 Adapty Flutter SDK 4.0 — which adds [Flow Builder](adapty-flow-builder) support — raises the minimums to **iOS 15.0+**, **Xcode 26+**, and **Flutter 3.32.0+** (Dart 3.8.0+). See [Adapty SDK 4.0](#adapty-sdk-40-swift-package-manager) below for the installation specifics.
 
 :::info
-Adapty is compatible with Google Play Billing Library up to 8.x. By default, Adapty works with Google Play Billing Library v7.0.0 but, if you want to force a later version, you can manually [add the dependency](https://developer.android.com/google/play/billing/integrate#dependency).
+Adapty Flutter SDK 4.0.4 and later works with Google Play Billing Library v8.
 
 Compatibility with a Billing Library version doesn't mean Adapty supports every feature Google introduced in it. Before you adopt a new Google Play billing capability, see [Product in Play Store](android-products).
 :::

--- a/src/content/docs/version-3.0/sdk-installation-kotlin-multiplatform.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-kotlin-multiplatform.mdx
@@ -30,7 +30,7 @@ For a complete implementation walkthrough, you can also see the video:
 Adapty Kotlin Multiplatform SDK is compatible with Xcode 16.2 and later.
 
 :::info
-Starting from SDK v3.17, Adapty SDK uses Google Play Billing Library v8.0.0 by default.
+Adapty Kotlin Multiplatform SDK 4.0 and later works with Google Play Billing Library v8.
 
 Compatibility with a Billing Library version doesn't mean Adapty supports every feature Google introduced in it. Before you adopt a new Google Play billing capability, see [Product in Play Store](android-products).
 :::

--- a/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
@@ -44,7 +44,7 @@ The Adapty React Native SDK requires iOS 15.0+.
 Building for iOS requires **Swift 6.0** or later. [Kids Mode](kids-mode-react-native) requires **Swift 6.1** or later.
 
 :::info
-Starting from SDK v3.17, Adapty SDK uses Google Play Billing Library v8.0.0 by default.
+Adapty React Native SDK 4.0.3 and later works with Google Play Billing Library v8.
 
 Compatibility with a Billing Library version doesn't mean Adapty supports every feature Google introduced in it. Before you adopt a new Google Play billing capability, see [Product in Play Store](android-products).
 :::

--- a/src/content/docs/version-3.0/sdk-installation-react-native-pure.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-pure.mdx
@@ -34,7 +34,7 @@ The Adapty React Native SDK requires iOS 15.0+.
 Building for iOS requires **Swift 6.0** or later. [Kids Mode](kids-mode-react-native) requires **Swift 6.1** or later.
 
 :::info
-Starting from SDK v3.17, Adapty SDK uses Google Play Billing Library v8.0.0 by default.
+Adapty React Native SDK 4.0.3 and later works with Google Play Billing Library v8.
 
 Compatibility with a Billing Library version doesn't mean Adapty supports every feature Google introduced in it. Before you adopt a new Google Play billing capability, see [Product in Play Store](android-products).
 :::


### PR DESCRIPTION
## What

Three fixes for Android billing and purchase docs, all verified against SDK source.

### Offer selection on Google Play (`add-product-to-paywall`)
The article said you can specify an offer "if desired". On Google Play, the offer selected on the paywall is the one applied at purchase: without it, the SDK falls back to the base plan and users are charged full price with no trial, even if the offer is active in Google Play Console. Rewritten to state that.

### Billing Library v8 support (7 installation articles)
The installation docs carried two wrong claims:
- Android/Flutter/Unity: "compatible with the Billing Library up to 8.x — force a later version by adding the dependency". SDK versions that don't bundle Billing Library 8 call an API that v8 removed, so forcing the v8 dependency breaks `restorePurchases`.
- RN/KMP/Capacitor: "Starting from SDK v3.17, Adapty SDK uses Google Play Billing Library v8.0.0 by default" — Android SDK 3.17.x pins billing 7.0.0.

Each article now states only the SDK version from which Billing Library v8 is supported: Android 4.0.2+, Flutter 4.0.4+, React Native 4.0.3+, Capacitor 4.0.2+, Unity 4.0+, KMP 4.0+.

### `subscriptionUpdateParams` (`android-making-purchases`)
Added a warning in the change-subscription section: pass the parameter only when switching from an active subscription on the same Google account. Passing it on a new purchase fails with `CURRENT_SUBSCRIPTION_TO_UPDATE_NOT_FOUND_IN_HISTORY`, whose message misleadingly points to an inactive subscription or a different Google account.

## Verification
- `check-mdx-parse` and `lint-mdx` pass on all changed files.
- Claims verified against the Android SDK source (ProductMapper, StoreManager, BillingClientExt across tags 3.17.2–4.1.0) and each wrapper's bundled `adapty-bom` pin.