### PR TITLE
docs: warn that fast refresh keeps stale activation parameters

### DIFF
--- a/src/content/docs/capacitor/sdk-installation-capacitor.mdx
+++ b/src/content/docs/capacitor/sdk-installation-capacitor.mdx
@@ -280,6 +280,10 @@ try {
 }
 ```
 
+:::note
+With this option enabled, the SDK skips the whole activation call once it has been activated, so changes to activation parameters don't take effect on a live reload. To apply new activation parameters, fully close the app and launch it again.
+:::
+
 ## Troubleshooting
 
 #### Minimum iOS version error

--- a/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
@@ -367,6 +367,10 @@ try {
 }
 ```
 
+:::note
+With this option enabled, the SDK skips the whole activation call once it has been activated, so changes to activation parameters don't take effect on a fast refresh. To apply new activation parameters, fully close the app and launch it again.
+:::
+
 ## Troubleshooting
 
 #### Minimum iOS version error

--- a/src/content/docs/version-3.0/sdk-installation-react-native-pure.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-pure.mdx
@@ -290,6 +290,10 @@ try {
 }
 ```
 
+:::note
+With this option enabled, the SDK skips the whole activation call once it has been activated, so changes to activation parameters don't take effect on a fast refresh. To apply new activation parameters, fully close the app and launch it again.
+:::
+
 #### Set up mock mode for local testing
 
 For local development and testing, you can enable mock mode to avoid needing sandbox App Store/Google Play accounts and speed up iteration. Mock mode completely bypasses Adapty's native modules and returns simulated data.


### PR DESCRIPTION
## What

The React Native (pure + Expo) and Capacitor installation guides recommend `__ignoreActivationOnFastRefresh` for development, but didn't mention its side effect: once the SDK is activated, the option makes the SDK skip the whole activation call, so any changed activation parameters are silently ignored on a fast refresh / live reload.

Each of the three troubleshooting sections now carries a note: to apply new activation parameters, fully close the app and launch it again.

## Verification

Behavior verified in SDK source: both the React Native and Capacitor 4.0.0 SDKs return early from `activate` before encoding the configuration or calling native code when the flag is set and the SDK is already activated (confirmed by the RN integration test "should skip second activation when flag is enabled").

`check-mdx-parse` and `lint-mdx` pass on all changed files.