### PR TITLE
docs: disambiguate App Store key pairs and add credential-save troubleshooting

### DIFF
--- a/src/content/docs/version-3.0/app-store-connection-configuration.mdx
+++ b/src/content/docs/version-3.0/app-store-connection-configuration.mdx
@@ -54,6 +54,10 @@ Without the **Apple app ID**, the **Create a new product and push to stores** op
 
 The **In-app purchase Issuer ID**, referred to as **Issuer ID** in App Store Connect, is a special ID that identifies the issuer who created the authentication token. The **In-App Purchase Key ID**, referred to as **Key ID** in App Store Connect, is a unique identifier associated with a cryptographic key you've generated in the [Generate In-App Purchase Key in App Store Connect](generate-in-app-purchase-key) section.  
 
+:::note
+App Store Connect has two key types whose fields are both labelled **Issuer ID** and **Key ID**. Steps 2–3 use the **In-App Purchase** key from the **Integrations** → **In-App Purchase** tab. The App Store Connect API key from the **Team keys** tab is a different key with its own IDs — you'll add it in [Step 6](#step-6-add-app-store-connect-api-key).
+:::
+
 1. Open **App Store Connect**. Proceed to [**Users and Access** → **Integrations** → **In-App Purchase**](https://appstoreconnect.apple.com/access/integrations/api/subs) section.
 2. In the **Active** list, find the key you've created in the [Generate In-App Purchase Key in App Store Connect](generate-in-app-purchase-key) section.
 
@@ -196,7 +200,11 @@ The **App Store shared secret**, also known as the App Store Connect Shared Secr
 
 ## Step 6. Add App Store Connect API key
 
-Generate an App Store Connect API key and add it to Adapty to be able to [manage your products in the App Store from the Adapty dashboard](create-product#create-product-and-push-to-store):
+Generate an App Store Connect API key and add it to Adapty to be able to [manage your products in the App Store from the Adapty dashboard](create-product#create-product-and-push-to-store).
+
+:::note
+This is a different key pair from the In-App Purchase key you added in [Steps 2–3](#step-2-provide-issuer-id-and-key-id). Generate the key in the **Team keys** tab and copy its **Issuer ID** and **Key ID** from there — the In-App Purchase key values won't work here.
+:::
 
 1. In App Store Connect, go to [**Users and Access > Integrations > Team keys**](https://appstoreconnect.apple.com/access/integrations/api) and click **+**.
 

--- a/src/content/docs/version-3.0/troubleshoot-app-store-integration.mdx
+++ b/src/content/docs/version-3.0/troubleshoot-app-store-integration.mdx
@@ -6,6 +6,18 @@ metadataTitle: "Troubleshoot App Store Integration | Adapty Docs"
 
 This article covers common App Store integration issues. Each section below lists the symptoms, root cause, and resolution.
 
+## "The provided field values are incorrect" when saving credentials
+
+When you save the In-App Purchase credentials, Adapty builds an authentication token from the **In-app purchase Issuer ID**, **In-app purchase Key ID**, and the **.p8 file**, and validates it against Apple. This error means Apple rejected the token. Verify the values in this order:
+
+1. **Key type.** The key must be an **In-App Purchase** key from **Users and Access** → **Integrations** → **In-App Purchase** in App Store Connect. A key from the **Team keys** tab (the App Store Connect API key) has its own **Issuer ID** and **Key ID**, but Apple rejects it here — that key belongs in [Step 6 of the configuration](app-store-connection-configuration#step-6-add-app-store-connect-api-key).
+2. **Same account and team.** The Issuer ID, Key ID, and .p8 file must come from the same App Store Connect team as the app. A key generated in another team's account — for example, an agency account — fails validation.
+3. **The .p8 file itself.** Upload the file exactly as downloaded from App Store Connect. A file recreated from pasted key contents often fails. App Store Connect lets you download the key only once, so if the original file is lost, generate a new key.
+4. **Bundle ID.** The Bundle ID must match your app's bundle ID in App Store Connect exactly — reverse-DNS format with no spaces, for example, `com.company.app`.
+5. **Hidden characters.** Re-copy each ID directly from App Store Connect. Stray whitespace or lookalike characters — for example, a lowercase `l` in place of the digit `1` — make validation fail.
+
+If all the values are correct, see the [Apple System Status page](https://www.apple.com/support/systemstatus/): validation calls Apple's servers, so an App Store Connect outage can fail a save even with correct values. Retry after the outage ends.
+
 ## Products don't appear
 
 Two surface symptoms point to the same root cause:


### PR DESCRIPTION
## What

Two fixes for the most common App Store credential-save failure.

### Key-pair disambiguation (`app-store-connection-configuration`)
The article uses two different Apple key pairs that App Store Connect both labels **Issuer ID** and **Key ID**: the In-App Purchase key (Steps 2–3) and the App Store Connect API key (Step 6). Nothing said they are different keys, which is the structural cause of the most common credential-save failure. Steps 2 and 6 now each carry a note naming the other key and where each is generated.

### New troubleshooting section (`troubleshoot-app-store-integration`)
Added a section for the **"The provided field values are incorrect"** error when saving In-App Purchase credentials. Grounded in the actual backend validation: Adapty builds a token from the entered Issuer ID, Key ID, and .p8 file and validates it against Apple's App Store Server API, so the error means Apple rejected the credentials. The checklist is ordered by likelihood: wrong key type (Team key instead of In-App Purchase key), key from another team/account, a .p8 recreated from pasted contents (with the download-once caveat), bundle ID format, and hidden/lookalike characters — with the Apple-outage check last and conditional.

## Verification
- Error message wording and validation flow verified against the dashboard backend.
- `check-mdx-parse` and `lint-mdx` pass on both changed files.