### PR TITLE
docs: clarify webhook expiry semantics, retry limits, and manual-grant events

### DIFF
--- a/src/content/docs/version-3.0/give-access-level-to-specific-customer.mdx
+++ b/src/content/docs/version-3.0/give-access-level-to-specific-customer.mdx
@@ -50,3 +50,9 @@ You can manually adjust the access level for a particular customer right in the 
 ## Give access level to a specific customer via API
 
 You also have the option to give a customer an access level from your server using the Adapty API. This comes in handy if you have bonuses for referrals or other events related to your products. Find additional details on the [Grant access level with server-side API](api-adapty/operations/grantAccessLevel) page.
+
+## Track manual grants on your backend
+
+If your [webhook integration](set-up-webhook-integration) has the [Access level updated](webhook-event-types-and-fields#for-access-level-updated-event) event enabled, Adapty sends it when you grant, update, or revoke an access level manually.
+
+No event is sent when the granted access expires: Adapty recalculates access on each request instead of storing a status change, so expiry doesn't trigger anything. If your backend needs to revoke features when the access ends, schedule the revocation from the expiration date you set when granting the access level.

--- a/src/content/docs/version-3.0/set-up-webhook-integration.mdx
+++ b/src/content/docs/version-3.0/set-up-webhook-integration.mdx
@@ -150,3 +150,7 @@ The event name can be any string. You cannot leave the fields empty for enabled 
 
 Webhooks are typically delivered within 5 to 60 seconds after the event occurs. Cancellation events, however, may take up to 2 hours to be delivered after a user cancels their subscription.
 If your server's response status code is outside the 200-404 range, Adapty retries delivery with exponential backoff. The first retry happens approximately **1 minute** after the initial failure, doubling on each subsequent attempt — up to 9 retries spread over 24 hours. We suggest you set up your webhook to do only basic validation of the event body from Adapty before responding. If your server can't process the event and you don't want Adapty to retry, use a status code within the 200-404 range. Also, handle any time-consuming tasks asynchronously and respond to Adapty quickly. If Adapty doesn't receive a response within 10 seconds, it will consider the attempt a failure and will retry.
+
+:::note
+Every event gets at least one delivery attempt, but two limits apply to retries. If your endpoint has had no successful delivery for 24 hours, Adapty stops retrying failed events for it until a delivery succeeds again. Also, an event that hasn't been delivered within 24 hours of its creation is no longer retried. Events that failed during a long outage are not resent automatically — reach out to the [Adapty support](mailto:support@adapty.io) to resend them.
+:::

--- a/src/content/docs/version-3.0/webhook-event-types-and-fields.mdx
+++ b/src/content/docs/version-3.0/webhook-event-types-and-fields.mdx
@@ -21,6 +21,10 @@ You can send all event types to your webhook or choose only some of them. You ca
 `subscription_renewal_reactivated` carries the **prior** product ID — the one that was active when the user cancelled — even if the user later reactivated by purchasing a different product. Apple keeps the same `original_transaction_id` across the cancel → reactivate chain, so this event reflects the original product. The new product surfaces in the next `subscription_renewed` event when billing for the new product begins.
 :::
 
+:::note
+On Google Play, Adapty can send a `subscription_started` event with all monetary fields set to zero — for example, when Google replaces one subscription with another or when the subscription starts with a no-charge phase. Don't count such events as revenue. When Google replaces a subscription, it issues a new purchase token, so Adapty reports the paid transaction under a different `store_transaction_id`.
+:::
+
 ## Webhook event structure
 
 Adapty will send you only those events you've chosen in the **Events names** section of the [Integrations ->  Webhooks](https://app.adapty.io/integrations/customwebhook) page.
@@ -246,7 +250,7 @@ The event properties for most event types are consistent (except for **Access Le
 | **store_offer_category**      | String        | Applied offer category. Possible values are `introductory`, `promotional`, `winback`.                                                                                                                                                                                                                                                                            |
 | **store_offer_discount_type** | String        | Applied offer type. Possible values are `free_trial`, `pay_as_you_go`, and `pay_up_front`.                                                                                                                                                                                                                                                                       |
 | **store_offer_number_of_periods** | Integer   | Number of base billing periods an offer discounts (1 or more). Present only when an offer applies. `null` for App Store pay-up-front offers and when the store doesn't report the offer duration. |
-| **subscription_expires_at**   | ISO 8601 date | The Expiration date of subscription. Usually in the future.                                                                                                                                                                                                                                                                                                      |
+| **subscription_expires_at**   | ISO 8601 date | <p>The expiration date of the subscription.</p><p>In refund, billing issue, grace period, and access level events, it holds the cancellation date or the grace period end when one applies. In purchase and renewal events, it holds the regular subscription expiration date.</p>                                |
 | **transaction_id**            | String        | Unique identifier for a transaction.                                                                                                                                                                                                                                                                                                                             |
 | **trial_duration**            | String        | Duration of a trial period in days. Sent in a format "{} days", for example, "7 days". Present in the trial connected event types only: `trial_started`, `trial_converted`, `trial_cancelled`.                                                                                                                                                                   |
 | **variation_id**              | UUID          | Unique ID of the paywall where the purchase was made.                                                                                                                                                                                                                                                                                                            |
@@ -349,9 +353,9 @@ Use this event to update the user’s access level in your database, grant or re
 | **developer_id**                   | String        | The ID of the placement where the transaction originated.    |
 | **environment**                    | String        | Possible values are `Sandbox` or `Production`.               |
 | **event_datetime**                 | ISO 8601 date | The date and time of the event.                              |
-| **expires_at**                     | ISO 8601 date | Date and time when the access will expire.                   |
-| **is_active**                      | Boolean       | Boolean indicating whether the access level is active.       |
-| **is_in_grace_period**             | Boolean       | Boolean indicating whether the profile is in the grace period. |
+| **expires_at**                     | ISO 8601 date | <p>Date and time when the access expires. Adapty computes `is_active` from this field.</p><p>During a grace period, it holds the end of the grace period; after a refund or cancellation, it holds the cancellation date. There is no separate field for the grace period end.</p> |
+| **is_active**                      | Boolean       | Boolean indicating whether the access level is active. Computed from `expires_at` (together with `starts_at` and `is_lifetime`) when the event is generated. |
+| **is_in_grace_period**             | Boolean       | Boolean indicating whether the profile is in the grace period. While `true`, `expires_at` holds the end of the grace period. |
 | **is_lifetime**                    | Boolean       | Boolean indicating whether the access level is lifetime.     |
 | **is_refund**                      | Boolean       | Boolean indicating whether the transaction is a refund.      |
 | **original_purchase_date**         | ISO 8601 date | For recurring subscriptions, the original purchase is the first transaction in the chain, its ID called original transaction ID  links the chain of renewals; later transactions are extensions of it. The original purchase date is the date and time of this first transaction. |


### PR DESCRIPTION
## What

Four verified gaps in the webhook/event docs, all confirmed against the backend source.

### `expires_at` is the authoritative gating timestamp (`webhook-event-types-and-fields`)
The access-level `expires_at` is what Adapty's own `is_active` derives from: during a grace period it holds the grace end, after a refund or cancellation it holds the cancellation date, and there is no dedicated grace-end field. The event-level `subscription_expires_at` follows different rules per event type (cancellation/grace-aware for refund, billing issue, grace, and access-level events; plain expiration for purchase and renewal events). The field rows now say all of this.

### Zero-value `subscription_started` on Google Play (same file)
Google replacement and no-charge orders produce a `subscription_started` with all monetary fields zero; replacement issues a new purchase token, so the paid transaction is reported under a different `store_transaction_id`. Added a note: don't count zero-value events as revenue.

### Webhook retry limits (`set-up-webhook-integration`)
The existing 9-retries-over-24h paragraph is accurate but incomplete. Added the two real limits: if an endpoint has had no successful delivery for 24 hours, Adapty stops retrying failures for it until a delivery succeeds again; and an event undelivered within 24 hours of creation is no longer retried. Long-outage events aren't resent automatically — support can resend them (there is no user-facing resend).

### Manual grants and expiry (`give-access-level-to-specific-customer`)
New section: `access_level_updated` fires when you grant, update, or revoke an access level manually (when enabled in the webhook config), but nothing fires at natural expiry — access is recalculated on read, so backends must schedule revocation from the expiration date set at grant time.

## Verification
- All claims verified against the backend: the `real_expires_date` fallback chain, `is_active` computed at read time, event emission call sites (no scheduler among them), the retry gate and queue age cap, and per-event-type `subscription_expires_at` sources.
- `check-mdx-parse` and `lint-mdx` pass on all changed files.