### PR TITLE
docs: clarify cohort day columns, filter sourcing, and analyticsDisabled scope

### DIFF
--- a/src/content/docs/version-3.0/analytics-cohorts.mdx
+++ b/src/content/docs/version-3.0/analytics-cohorts.mdx
@@ -38,6 +38,12 @@ Let's see in the example of cohorts by renewals how the table is formed. To buil
 
 Every next column in the row shows the number of users who renewed a subscription to this period. M3 stands for month 3 and means that subscribers had 3 consecutive renewals to this point, W7 stands for week 7, and Y2 stands for year 2. Sometimes you can see P2 in cohorts. P stands for Period of subscription. Adapty displays instead of W/M/Y when there are multiple products with different renewal periods present in the same cohort.
 
+In the **by days** mode, column headings show day horizons instead: `7d`, `28d`, `183d`, and so on. A day column is cumulative: `183d` counts the users who made at least one paid transaction within their first 183 days after install, or the revenue they generated in that window — not the payments made on day 183. A cohort doesn't need to reach that age for the column to show data: for a younger cohort, the value covers what has happened so far and keeps growing.
+
+:::note
+Cumulative day columns apply to absolute values. If you display relative values, the Revenue columns stay cumulative, while the Subscriptions and Payers columns show each column's own share of the cohort total.
+:::
+
 We use gradient colors to highlight differences in cohort values. The biggest numbers have more saturated colors.
 
 In the image below you can see a typical cohort.
@@ -78,6 +84,8 @@ By default, Adapty builds cohorts using data from all purchases. You can filter 
 <ZoomImage id="ad10de0-cohorts_filter.webp" width="700px" alt="Cohort filter controls" />
 
 On the right of the control panel, there's a button to export cohort data to CSV. You can then open it in Excel, or Google Sheets, or import it into your own analytical system.
+
+The export contains the cohort rows and totals for the currently selected metric — there is no **Country** column or any other breakdown. To split cohorts by country, apply a **Country** filter and export once per country, or request cohort data with a country filter through the [Export API](export-analytics-api).
 
 There are 6 metrics that can be shown in cohorts: Subscriptions, Payers, Revenue, ARPU, ARPPU, and ARPAS. You can either display them as absolute values or as a relative change from the start of the cohort.
 

--- a/src/content/docs/version-3.0/analytics-integration.mdx
+++ b/src/content/docs/version-3.0/analytics-integration.mdx
@@ -142,6 +142,12 @@ You may want to stop sending analytics events for a specific customer. This is u
 To disable external analytics for a customer, use `updateProfile()` method. Create `AdaptyProfileParameters.Builder` object and set the corresponding value to it.  
 When external analytics is blocked, Adapty won't be sending any events to any integrations for the specific user. If you want to disable an integration for all users of your app, just turn it off in Adapty Dashboard.
 
+:::warning
+Blocking external analytics stops event delivery to **all** integrations for this user, including custom [webhooks](webhook). Don't use it if your backend relies on webhook events to manage this user's access.
+
+The setting isn't retroactive: events created before it was set are still delivered. It also doesn't affect Adapty's own analytics — the user's transactions still count in the dashboard charts.
+:::
+
 <Tabs groupId="current-os" queryString>
 <TabItem value="swift" label="Swift" default>
 ```swift showLineNumbers

--- a/src/content/docs/version-3.0/billing-issue.mdx
+++ b/src/content/docs/version-3.0/billing-issue.mdx
@@ -6,7 +6,7 @@ metadataTitle: "Resolving Subscription Billing Issues | Adapty Docs"
 
 import ZoomImage from '@site/src/components/ZoomImage.astro';
 
-The Billing issue chart displays the number of subscriptions that have entered the Billing Issue state. This state is typically triggered when the store, such as Apple or Google, is unable to receive payment from the subscriber for some reason. This could happen due to reasons such as an expired credit card or insufficient funds.
+The Billing issue chart displays the number of subscriptions that have entered the Billing Issue state. This state is typically triggered when the store, such as Apple or Google, is unable to receive payment from the subscriber for some reason. This could happen due to reasons such as an expired credit card or insufficient funds. These are examples only: the stores don't share the specific decline reason, so Adapty can't break billing issues down by reason.
 
 <ZoomImage id="8749d28-CleanShot_2023-07-11_at_15.21.262x.webp" width="700px" alt="Billing issue chart" />
 

--- a/src/content/docs/version-3.0/controls-filters-grouping-compare-proceeds.mdx
+++ b/src/content/docs/version-3.0/controls-filters-grouping-compare-proceeds.mdx
@@ -97,6 +97,10 @@ The comparison appears:
 
 Not every analytics view supports every filter or group attribute above. ARPU and Installs in the Charts tab are limited to Attribution, Country, Segment, Store, and (filter only) A/B tests. The LTV, Cohorts, Funnels, Retention, and Conversion tabs each support a different subset. For exact support, see the article for that chart or tab.
 
+:::note
+Filter dropdowns list only values Adapty has already received: an option appears after Adapty processes at least one transaction carrying that value. For example, if a campaign exists in your ad network or MMP but no attributed transaction has reached Adapty yet, the campaign isn't in the list. Segments are the exception — they come from your segment definitions and appear before any transactions.
+:::
+
 <ZoomImage id="84f2f49-CleanShot_2023-09-12_at_15.15.152x.webp" width="700px" alt="Filter and grouping options" />
 
 ### How country is determined


### PR DESCRIPTION
## What

Five analytics gaps from support-ticket mining, all verified against the backend before writing.

### Cohort day-horizon columns (`analytics-cohorts`)
The article explained M3/W7/Y2 headings but never said what a `183d` column counts. Added: a day column is **cumulative** — users with at least one paid transaction within their first N days after install (or the revenue from that window) — not payments made on day N, and a cohort doesn't need to be fully aged for the column to show data. Backend check surfaced a subtlety, added as a note: in relative display, Revenue stays cumulative while Subscriptions/Payers show per-column shares.

### Cohort CSV export (`analytics-cohorts`)
The CSV has a fixed column set with no Country column (verified against the export code). Documented the workarounds that actually exist: filter by country and export per country, or use the Export API with a country filter.

### Filter dropdown values (`controls-filters-grouping-compare-proceeds`)
Dropdown options are derived from ingested transactions (a ClickHouse table fed only by materialized views over transactions — no static registry), so a campaign known to an MMP but with no attributed transaction in Adapty isn't listed. Segments are the verified exception. This explains the recurring "the campaign is in my MMP but not in Adapty" question.

### `analyticsDisabled` scope (`analytics-integration`)
Added a warning: the flag blocks event delivery to **all** integrations for the user, including custom webhooks (don't use it when webhooks drive access management); it isn't retroactive; and it doesn't affect Adapty's own dashboard charts.

### Billing issue reasons (`billing-issue`)
The "expired credit card or insufficient funds" wording is now marked as examples only — the stores don't share the specific decline reason, so no per-reason breakdown is available.

## Verification
- Cohort bucketing/cumulation, filter-values sourcing, CSV columns, and the analytics_disabled gate all verified against the backend source.
- `check-mdx-parse` and `lint-mdx` pass on all changed files.