### PR TITLE
docs: add Flow Builder pitfalls the builder can't surface

### DIFF
--- a/src/content/docs/guides/flow-builder/builder-loaders-and-progress-bars.mdx
+++ b/src/content/docs/guides/flow-builder/builder-loaders-and-progress-bars.mdx
@@ -64,3 +64,5 @@ The category provides three templates:
 :::warning
 A loader requires a **trigger** to appear and disappear. Open the **Interactions** tab to set up this logic — for example, show it after the user submits a quiz.
 :::
+
+A loader's **Duration** setting controls the length of its fill or spin **animation**, not how long the screen stays visible. An **On screen appear** trigger with a **Navigate to screen** action advances immediately, without waiting for the animation. To keep a loading screen on for a set time, add a [Timer](flow-timer) with an **On timer end** trigger that navigates to the next screen. Timer duration is set in whole seconds.

--- a/src/content/docs/guides/flow-builder/builder-styling.mdx
+++ b/src/content/docs/guides/flow-builder/builder-styling.mdx
@@ -161,6 +161,10 @@ For [custom fonts](using-custom-fonts-in-flow-builder), the **Weight**, **Bold**
 * **Weight**: Select a font weight from the dropdown
 * **Size**: Select a size from the dropdown or type a custom value
 
+:::note
+Text size renders differently per platform: Android scales flow text with the system font size setting, while iOS renders the exact size you set. Test your layout on Android with an increased system font size — text that fits on iOS can wrap or overflow there.
+:::
+
 ### Color
 
 Click the color swatch to open the color picker. Enter a hex value, use the palette, or select one of the [reusable styles](#reusable-styles). Adjust the opacity slider to make the text semi-transparent.

--- a/src/content/docs/guides/flow-builder/flow-common-issues.mdx
+++ b/src/content/docs/guides/flow-builder/flow-common-issues.mdx
@@ -29,6 +29,34 @@ You can't publish or preview your flow if any of the following issues are presen
 
 To catch these before publishing, [preview the flow in the Adapty app](paywall-device-compatibility-preview). If the flow fails to load there, the error message gives you more detail.
 
+## Publishing fails with "Something went wrong"
+
+This error means the publish request failed on the Adapty side, not that your flow is misconfigured — that's why the message is generic. Your live version is unchanged. Copy the **Request ID** from the error message and send it to [support@adapty.io](mailto:support@adapty.io) so the team can locate the failed request.
+
+## An offer doesn't apply at purchase
+
+The Builder validates that each product element has a product, but it doesn't validate the product's offer. If the offer is later changed or removed in the store or in Adapty, the flow still publishes, and the purchase runs without the offer. After changing offers, reopen the flow, reselect the offer for each affected product element, and republish.
+
+## A color renders wrong when opacity is set
+
+Enter colors as 6-digit hex codes, such as `#FFFFFF`. A shorthand code such as `#FFF` combined with an opacity below 100% produces an invalid color.
+
+## Typography edits don't reach an element state
+
+Once a state, such as **Selected**, has its own typography settings, edits to the **Default** state's typography — including applying a different text style — don't affect that state. Edit the state's typography directly.
+
+## Elements lose their styling after a text style is deleted
+
+Deleting a [text style](builder-styling#text-styles) doesn't copy its settings into the elements that use it: those elements fall back to default typography. Before deleting a style, reassign the affected elements to another style or set their typography manually.
+
+## Conditions and variables break after an element ID change
+
+Conditions and text variables reference elements by **Element ID**, and changing the ID doesn't update the references — they silently stop resolving. Set the Element ID before referencing it. If you have to change it, update every condition and variable reference to match. The exception is progress-bar segments: renaming a segment updates its references automatically.
+
+## A condition or variable resolves to an empty value
+
+The variable picker lists fields from every screen, so a condition or text variable can reference an input the user hasn't filled in yet. At runtime, such a reference resolves to an empty value. Reference only fields collected earlier in the flow.
+
 ## A Set variable action doesn't change the selected product
 
 Which product is selected isn't a variable you can assign, so **Set variable** can't move the selection. Use the [**Select product**](onboarding-actions#select-product) action instead.


### PR DESCRIPTION
## What

Flow Builder gaps from support-ticket mining, each verified against the unified-builder source (and the SDKs for the font note) and adjusted where the original claim didn't hold.

### Six new common-issues entries (`flow-common-issues`)
- **Publishing fails with "Something went wrong"** — a server-side failure: the live version is unchanged, and the Request ID in the toast is what support needs.
- **An offer doesn't apply at purchase** — the builder validates the product on each product element but never the offer, so an offer changed or removed after selection publishes silently and only fails at runtime.
- **A color renders wrong when opacity is set** — prescription form of a verified rendering defect: use 6-digit hex; shorthand (`#FFF`) plus opacity below 100% produces an invalid color. (The mined claim said shorthand hex fails schema validation — it doesn't; no publish-time schema validation exists, so the entry documents the real failure instead.)
- **Typography edits don't reach an element state** — a state with its own typography ignores later Default-state edits, including text-style changes.
- **Elements lose their styling after a text style is deleted** — deletion doesn't inline the style's settings; elements fall back to defaults.
- **Conditions and variables break after an element ID change** — references are by Element ID string and aren't rewritten on rename; progress-bar segments are the verified exception (their rename updates references).
- **A condition or variable resolves to an empty value** — re-scoped from "tap actions referencing off-screen fields" (impossible to author; the element picker is screen-scoped) to the real path: the variable picker lists fields from every screen.

### Loader duration (`builder-loaders-and-progress-bars`)
Duration is the animation length, not screen dwell time; an On screen appear trigger with Navigate to screen advances immediately. Documented the working pattern: a Timer with On timer end (whole seconds).

### Cross-platform text scaling (`builder-styling`)
Android renders flow text in scaled units that follow the system font size; iOS renders fixed sizes with no Dynamic Type. Added a note under Size and weight to test layouts on Android with an increased system font size.

## Verification
- Builder claims verified in the unified-builder source (validation, style deletion, rename commands, variable picker, loader renderer, publish-error toast copy).
- Font behavior verified in both the Android and iOS SDK UI renderers.
- `check-mdx-parse` and `lint-mdx` pass on all changed files.