### PR TITLE
docs: document access transfer, segment operators, deletion blockers, and search matching

### DIFF
--- a/src/content/docs/version-3.0/delete-product.mdx
+++ b/src/content/docs/version-3.0/delete-product.mdx
@@ -7,7 +7,11 @@ metadataTitle: "How to Delete a Product | Adapty Docs"
 import Zoom from 'react-medium-image-zoom';
 import 'react-medium-image-zoom/dist/styles.css';
 
-You can only delete products that are not used in paywalls.
+You can delete a product only when nothing uses it: paywalls, flows, purchase groups, and virtual currencies all block deletion.
+
+:::note
+An archived paywall releases its products, but an archived **flow** doesn't — its paywalls still count as usage, and the deletion error names them. If a product looks unused but can't be deleted, look through your archived flows: on the **Flows** page, open the **All states** filter and select **Archived**.
+:::
 
 To delete the product:
 

--- a/src/content/docs/version-3.0/profiles-crm.mdx
+++ b/src/content/docs/version-3.0/profiles-crm.mdx
@@ -43,6 +43,8 @@ In the Profiles list, you can search for a specific user by:
 - **Email**: The user's email, if sent as a custom attribute.
 - **Transaction ID**: The store transaction ID from a purchase.
 
+The search matches the full value exactly: partial matches don't work, and surrounding whitespace makes the search return nothing — paste the complete identifier with no extra spaces. Customer user ID, email, and transaction ID are also case-sensitive.
+
 Click any row to open the user's full profile.
 
 ## Subscription state

--- a/src/content/docs/version-3.0/segments.mdx
+++ b/src/content/docs/version-3.0/segments.mdx
@@ -127,6 +127,12 @@ After you fill in the required fields, you can use custom attributes in your seg
 
 Each profile can have up to 30 custom attributes.
 
+### How operators match missing attributes
+
+The **≠** operator matches only profiles where the attribute is set: a profile with no value for the attribute doesn't match `attribute ≠ value`. The same applies to the comparison operators (`>`, `<`, `≥`, `≤`, `between`). To match profiles without the attribute, use the **is not set** operator. To target every profile except those with a specific value, combine `≠` with **is not set** — or set an explicit value on every profile and filter with `≠` alone.
+
+The comparison is also typed: if a profile stores the attribute with a different type than the segment compares — for example, a string value where the segment expects a number — the profile counts as not having the attribute.
+
 ## Total number and random sample
 
 After you create a segment, Adapty shows the total number of users that match the segment criteria.

--- a/src/content/docs/version-3.0/sharing-paid-access-between-user-accounts.mdx
+++ b/src/content/docs/version-3.0/sharing-paid-access-between-user-accounts.mdx
@@ -71,6 +71,10 @@ Adapty revokes the old profile only when the new profile has a [Customer User ID
 To avoid this, call the SDK methods in order: `activate` → `identify` → `restorePurchases`.
 :::
 
+:::warning
+Transfer moves the access level itself, not just the store purchase. When a restore transfers access to a new profile, Adapty revokes that access level from the previous profile even if a different store granted it — for example, a web (Stripe) purchase that maps to the same access level. If web and in-app purchases must stay independent, map their products to separate access levels.
+:::
+
 ## Disable paid access sharing
 
 This setting is **only appropriate** for applications with **mandatory authentication** or an independent access management implementation. In other cases, the users may not be able to access their purchases, and your application risks **failing the mandatory store review**.


### PR DESCRIPTION
## What

Four verified gaps around profiles and access, each checked against the backend before writing.

### Transfer mode and mixed-store access levels (`sharing-paid-access-between-user-accounts`)
With **Transfer access to new user**, revocation is keyed by access level with no store scoping — so when a restore transfers access to a new profile, Adapty revokes that access level from the previous profile even if a web (Stripe) purchase granted it. Added a warning with the prescription: map web and in-app products to separate access levels when they must stay independent.

### Segment operator semantics (`segments`)
New subsection: `≠` and the comparison operators match only profiles where the attribute is set — a profile lacking the attribute doesn't match `attribute ≠ value`. **Is not set** is the operator that matches missing attributes. Also documented the typed-comparison nuance: an attribute stored with a mismatched type counts as not set. (The mined claim said even "is not set" required the attribute to exist — the backend shows the opposite, so the doc states the verified behavior.)

### Product deletion blockers (`delete-product`)
The article claimed only paywalls block deletion. Completed the list (paywalls, flows, purchase groups, virtual currencies) and documented the asymmetry the backend shows: archiving a paywall releases its products, archiving a flow doesn't — its internal paywalls still count as usage. Added where to find them (Flows page → All states filter → Archived).

### Profiles search matching (`profiles-crm`)
The search is exact full-value with no trimming — surrounding whitespace returns nothing — and customer user ID, email, and transaction ID are case-sensitive (profile ID is UUID-normalized, so no case claim there).

## Verification
- All claims verified against the backend: the transfer/revoke path, the segment filter evaluator, the product-deletion validation and archive flags, and the CRM search adapter.
- `check-mdx-parse` and `lint-mdx` pass on all changed files.