### PR TITLE
docs: remove the Background blur effect from Flow Builder docs

### DIFF
--- a/src/content/docs/guides/flow-builder/builder-containers.mdx
+++ b/src/content/docs/guides/flow-builder/builder-containers.mdx
@@ -140,7 +140,7 @@ Walkthrough: [Show all plans in a bottom sheet](show-plans-bottom-sheet)
 
 A **Bottom Sheet** is a layout panel that slides up from the bottom of the screen, on top of the underlying content.
 
-The sheet always blurs anything behind it; the blur can't be turned off. Trigger it on tap — for example, behind a **Show all plans** link — rather than on screen load.
+Trigger the sheet on tap — for example, behind a **Show all plans** link — rather than on screen load.
 
 ### Structure
 

--- a/src/content/docs/guides/flow-builder/builder-styling.mdx
+++ b/src/content/docs/guides/flow-builder/builder-styling.mdx
@@ -96,7 +96,6 @@ Click the plus button <Inline id="plus.svg" alt="Plus" /> next to **Effects** to
 
 * **Drop shadow**: A shadow behind the element
 * **Inner shadow**: A shadow inside the element's boundaries
-* **Background blur**: Blurs the background
 * **Layer blur**: Blurs the element and its children
 
 You can stack multiple effects on the same element. Toggle its visibility <Inline id="eye.svg" alt="Show" /> to temporarily disable an effect.

--- a/src/content/docs/guides/flow-builder/builder-ui.mdx
+++ b/src/content/docs/guides/flow-builder/builder-ui.mdx
@@ -124,7 +124,7 @@ The **Design** tab allows you to configure the visual appearance and layout of t
 * **Content** (text elements only): Edit the element's text content, insert [variables](#variables), and manage localizations.
 * **Typography** (text elements only): Configure font, weight, size, color, alignment, decoration, and truncation.
 * **Spacing**: Set the element's margin and padding.
-* **Effects**: Add drop shadows, inner shadows, background blur, or layer blur.
+* **Effects**: Add drop shadows, inner shadows, or layer blur.
 * **Animation**: Add animated effects (e.g., Pulse) and configure their timing and intensity.
 * **Appearance**: Adjust opacity and rotation.
 * **Layout**: Choose a layout direction (vertical or horizontal) and determine how the children are distributed.


### PR DESCRIPTION
## What changed

The **Background blur** effect was removed from the Flow Builder, so this PR removes it from the docs:

- **builder-styling.mdx** — deleted the **Background blur** bullet from the Effects list (Drop shadow, Inner shadow, and Layer blur remain).
- **builder-ui.mdx** — the Effects line in the Design-tab overview now reads "Add drop shadows, inner shadows, or layer blur."
- **builder-containers.mdx** — removed the note that the Bottom Sheet always blurs the content behind it; the advice to trigger the sheet on tap is kept.

## Notes

- No remaining "background blur" mentions in English docs, reusables, or API specs (verified by grep). Locale files are auto-retranslated on push to main.
- The `effects.webp` screenshot in builder-styling.mdx may still show the Background blur option and could need a reshoot.