### PR TITLE
docs: clarify Stripe mapping, store notification statuses, and RC import limits

### DIFF
--- a/src/content/docs/version-3.0/enable-app-store-server-notifications.mdx
+++ b/src/content/docs/version-3.0/enable-app-store-server-notifications.mdx
@@ -31,6 +31,12 @@ Adapty iOS SDK 2.10.0 or later is required for full App Store Server Notificatio
 2. Open [App Store Connect](https://appstoreconnect.apple.com/apps). Select your app and proceed to **General** → **App Information** section, **App Store Server Notifications** subsection. 
 3. Paste the copied **URL for App Store server notification** into the **Production Server URL** and **Sandbox Server URL** fields.
 
+:::warning
+Fill in both URL fields. Without the **Production Server URL**, Adapty doesn't learn about renewals, expirations, and refunds that happen outside the app. If production notifications were missing for a period, contact [support@adapty.io](mailto:support@adapty.io): Adapty can restore the missed history from Apple using a list of `apple_original_transaction_id` values, without creating duplicates.
+:::
+
+After you save the URLs, the notifications status in the Adapty Dashboard changes only when Apple sends the first real notification — that is, when the first subscription event, such as a purchase or a renewal, occurs. Apple's test notification doesn't change it. A waiting status right after setup doesn't mean the connection is broken.
+
    
 
 <Zoom>

--- a/src/content/docs/version-3.0/enable-real-time-developer-notifications-rtdn.mdx
+++ b/src/content/docs/version-3.0/enable-real-time-developer-notifications-rtdn.mdx
@@ -32,6 +32,10 @@ Google Play reports renewals, cancellations, refunds, and billing issues to Adap
 
 2. Go back to [**App settings** > **Android SDK**](https://app.adapty.io/settings/android-sdk) in Adapty. Once Adapty receives the notification, the status tag in the **Google Play RTDN topic name** section reads **Active**.
 
+   :::note
+   The test notification only verifies the connection. It doesn't create purchase events, so the [Event Feed](event-feed) stays empty after a test — events appear when real transactions occur.
+   :::
+
    <ZoomImage id="gp-adapty-rtdn-active.webp" width="700px" alt="Google Play RTDN topic name section in Adapty showing the Active status tag" />
 
 ## Forward raw Google events

--- a/src/content/docs/version-3.0/migration-from-revenuecat.mdx
+++ b/src/content/docs/version-3.0/migration-from-revenuecat.mdx
@@ -183,6 +183,12 @@ Our Support Team will import your transactions to Adapty. The following data wil
 
 In addition, integration identifiers for the following integrations will be imported: Amplitude, Mixpanel, AppsFlyer, Adjust, and FacebookAds.
 
+### What doesn't come across
+
+- Every transaction is re-validated with the store during import, so rows the store no longer recognizes are dropped.
+- Rows without a real store transaction ID — for example, RevenueCat promotional or manually granted entitlements — import as profiles without transactions. To restore such users' access, grant them an access level with the [server-side API](api-adapty/operations/grantAccessLevel).
+- Refund and billing-issue history isn't carried over verbatim: a refund keeps only its cancellation date, and a subscription's billing-issue state is recorded as of the import, not with the historical dates.
+
 ## FAQ
 
 ### I successfully installed Adapty SDK and released a new app version with it. What will happen to my legacy subscribers who did not update to a version with Adapty SDK?

--- a/src/content/docs/version-3.0/stripe.mdx
+++ b/src/content/docs/version-3.0/stripe.mdx
@@ -193,6 +193,10 @@ Products are required! Be sure to create your Stripe products in the Adapty Dash
 
 We treat Stripe the same way as App Store and Google Play: it is just another store where you sell your digital products. So it is configured similarly: simply add Stripe products (namely their `product_id` and `price_id`) to the Products section of Adapty:
 
+:::warning
+Adapty matches incoming Stripe events by the exact `product_id` + `price_id` pair. Changing a price in Stripe creates a new `price_id`, and events for purchases on the new price silently stop matching: Stripe shows the webhook as delivered, but Adapty doesn't record the transactions. After any price change, make sure every `price_id` you sell is added to a product in Adapty.
+:::
+
 <Zoom>
   <img src="/assets/shared/img/stripe-add-product.webp"
   style={{
@@ -368,6 +372,10 @@ Adapty records one-time (non-subscription) purchases made through Stripe Checkou
 Adapty takes the product from the first line item of the session, so a session that sells several products records only the first one.
 
 Refunds for these purchases are not applied yet: Stripe delivers `charge.refunded`, but Adapty doesn't revoke access for a one-time purchase bought through Checkout or a Payment Link. Refunds of subscriptions and of one-time purchases billed through a Stripe invoice work as usual.
+
+### One Stripe account connected to several Adapty apps
+
+The webhook endpoint that receives an event decides which Adapty app processes it — each Adapty app has its own endpoint URL — not the restricted API key. Every endpoint you register in Stripe receives every event, and each app processes its copy independently. An app ignores events for products that aren't added to it, so apps with separate product sets coexist safely. However, if the same Stripe product and price are added to more than one app, each of those apps records the transaction.
 
 ## Get more from your Stripe data
 Once you integrate with Stripe, Adapty is ready to provide insights right away. To make the most of your Stripe data, you can set up additional Adapty integrations to forward Stripe events—bringing all your subscription analytics into a single Adapty Dashboard.


### PR DESCRIPTION
## What

Four integration gaps from support-ticket mining, all verified against the backend before writing.

### Stripe (`stripe`)
- **Price changes orphan the mapping**: Adapty matches Stripe events by the exact `product_id` + `price_id` pair; a price change mints a new `price_id`, and mismatched events are silently discarded while Stripe shows the webhook as delivered (the endpoint returns 200 unconditionally, and the handler drops unknown products without logging). Added a warning in the add-products step: keep every sold `price_id` mapped.
- **One Stripe account, several Adapty apps**: which app processes an event is decided by the receiving endpoint URL (each app has its own), not the restricted key; every endpoint receives every event with no cross-app dedup. Documented with the verified nuance that unmapped products are ignored, so apps with disjoint product sets coexist safely.

### App Store Server Notifications (`enable-app-store-server-notifications`)
An empty Production Server URL loses renewals, expirations, and refunds; missed history can be restored by support from a list of `apple_original_transaction_id` values (the importer re-fetches from Apple and is dedup-safe). The dashboard status flips only on the first real notification — Apple's TEST notification returns before the status is marked — so a waiting status right after setup isn't a misconfiguration.

### Google RTDN (`enable-real-time-developer-notifications-rtdn`)
The test notification flips the status to Active but carries no purchase token, so no purchase events are created — an empty Event Feed after a test is expected.

### RevenueCat migration (`migration-from-revenuecat`)
New "What doesn't come across" list: transactions are re-validated with the store during import (unrecognized rows are dropped); rows without a real store transaction ID (promotional/granted entitlements) import as profiles without transactions — restore access via the server-side grant; refund and billing-issue history isn't carried verbatim. The mined "sandbox rows can't be imported" claim was dropped — the importer explicitly falls back to Apple's sandbox endpoint, so it's false.

## Verification
- All claims verified against the backend: the Stripe webhook handler and routing, the store-event status repository and TEST short-circuit, the RTDN decoder, and the historical-import pipeline.
- `check-mdx-parse` and `lint-mdx` pass on all changed files.