### PR TITLE
docs: document the footer's Vertical scroll requirement

### DIFF
--- a/src/content/docs/guides/flow-builder/builder-containers.mdx
+++ b/src/content/docs/guides/flow-builder/builder-containers.mdx
@@ -186,6 +186,10 @@ Unlike regular elements, the footer reaches into the device's bottom safe area: 
 
 Only one footer is allowed per screen. You cannot duplicate an existing footer, or add a new one.
 
+:::warning
+Keep [**Vertical scroll**](paywall-layout-and-products#scroll) enabled on any screen with a footer. With the setting off, the footer doesn't render.
+:::
+
 ### Footer vs. a regular fixed element
 
 Both stay on screen while content scrolls. Pick the option that matches what you need:

--- a/src/content/docs/guides/flow-builder/flow-common-issues.mdx
+++ b/src/content/docs/guides/flow-builder/flow-common-issues.mdx
@@ -74,3 +74,7 @@ These formats aren't supported:
 
 - **Animated GIFs and animated WEBPs**: To add motion, use a Video element instead.
 - **SVG**: Export the file as PNG or WEBP. For icons, you don't upload anything — the Icon element draws from the bundled [Tabler Icons](custom-media#icon) library.
+
+## A footer doesn't render
+
+A footer renders only on a screen where **Vertical scroll** is enabled. Enable **Vertical scroll** in [**Screen settings** > **Scroll**](paywall-layout-and-products#scroll).

--- a/src/content/docs/version-3.0/paywall-layout-and-products.mdx
+++ b/src/content/docs/version-3.0/paywall-layout-and-products.mdx
@@ -136,7 +136,7 @@ Adjusts the screen padding for each side (top, right, bottom, left).
 Controls overflow behavior. Enable **Vertical scroll** to allow the screen content to scroll when it exceeds viewport height.
 
 :::link
-Use a [Footer](builder-containers#footer) to pin content to the bottom of the screen when the screen is overflowing.
+Use a [Footer](builder-containers#footer) to pin content to the bottom of the screen when the screen is overflowing. A footer needs **Vertical scroll** enabled to render.
 :::
 
 ### Selectable groups


### PR DESCRIPTION
A footer renders only on a screen where **Vertical scroll** is enabled. With the setting off, the footer doesn't render at runtime.

The requirement is now stated at all three points a reader can reach it, each linking to the others:

- **Containers > Footer** — the rule, phrased as a requirement ("keep Vertical scroll enabled") rather than a description of the failure, so it holds whether or not the Builder later blocks the combination.
- **Screens and Layers > Scroll** — one clause on the existing footer callout, so the reader is warned at the toggle itself and not only in the Footer section.
- **Common issues** — a troubleshooting entry naming where the setting lives (**Screen settings** > **Scroll**).

The label was verified against the builder frontend. Note that the Builder canvas renders the footer regardless of the setting, so this constraint won't reproduce in the editor preview.

### Verification

- `check-links-diff`: 0 broken, 0 stale across 41 links
- `lint-prose`: clean on every added line
- `check-mdx-parse`: all files parse