### PR TITLE
docs: name the observer-mode handler API in the cross-platform SDK guides

### DIFF
--- a/src/content/docs/version-3.0/implement-observer-mode-capacitor.mdx
+++ b/src/content/docs/version-3.0/implement-observer-mode-capacitor.mdx
@@ -14,7 +14,7 @@ If this meets your needs, you only need to:
 2. [Report transactions](report-transactions-observer-mode-capacitor) from your existing purchase infrastructure to Adapty.
 
 :::tip
-In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: when a user taps the purchase or restore button, the SDK hands the action over to your code so you can perform the purchase or restore yourself. See [Present flows in Observer mode](capacitor-present-flows-in-observer-mode).
+In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: set the `onObserverPurchaseInitiated` and `onObserverRestoreInitiated` event handlers to perform the purchase or restore with your own code when a user taps the corresponding button. See [Present flows in Observer mode](capacitor-present-flows-in-observer-mode).
 :::
 
 ### Observer mode setup

--- a/src/content/docs/version-3.0/implement-observer-mode-flutter.mdx
+++ b/src/content/docs/version-3.0/implement-observer-mode-flutter.mdx
@@ -13,6 +13,10 @@ If this meets your needs, you only need to:
 1. Turn it on when configuring the Adapty SDK by setting the `observerMode` parameter to `true`. Follow the setup instructions for [Flutter](sdk-installation-flutter#activate-adapty-module-of-adapty-sdk).
 2. [Report transactions](report-transactions-observer-mode-flutter) from your existing purchase infrastructure to Adapty.
 
+:::tip
+In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: register an `AdaptyUIObserverModeResolver` with `setObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button.
+:::
+
 ## Observer mode setup
 
 Turn on the Observer mode if you handle purchases and subscription status yourself and use Adapty for sending subscription events and analytics.
@@ -41,7 +45,3 @@ If you also want to use Adapty's flows, paywalls, and A/B testing features, you 
 
 1. Display [remote config paywalls](present-remote-config-paywalls-flutter) as usual. For flows & paywalls built in the Flow Builder, see [Present flows in Observer mode](flutter-present-flows-in-observer-mode).
 2. [Associate flows & paywalls](report-transactions-observer-mode-flutter) with purchase transactions. 
-
-:::tip
-In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: register an `AdaptyUIObserverModeResolver` with `setObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button.
-:::

--- a/src/content/docs/version-3.0/implement-observer-mode-flutter.mdx
+++ b/src/content/docs/version-3.0/implement-observer-mode-flutter.mdx
@@ -43,5 +43,5 @@ If you also want to use Adapty's flows, paywalls, and A/B testing features, you 
 2. [Associate flows & paywalls](report-transactions-observer-mode-flutter) with purchase transactions. 
 
 :::tip
-In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: register an `AdaptyUIObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button.
+In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: register an `AdaptyUIObserverModeResolver` with `setObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button.
 :::

--- a/src/content/docs/version-3.0/implement-observer-mode-flutter.mdx
+++ b/src/content/docs/version-3.0/implement-observer-mode-flutter.mdx
@@ -14,7 +14,7 @@ If this meets your needs, you only need to:
 2. [Report transactions](report-transactions-observer-mode-flutter) from your existing purchase infrastructure to Adapty.
 
 :::tip
-In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: register an `AdaptyUIObserverModeResolver` with `setObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button.
+In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: register an `AdaptyUIObserverModeResolver` with `setObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button. See [Present flows in Observer mode](flutter-present-flows-in-observer-mode).
 :::
 
 ## Observer mode setup

--- a/src/content/docs/version-3.0/implement-observer-mode-kmp.mdx
+++ b/src/content/docs/version-3.0/implement-observer-mode-kmp.mdx
@@ -17,7 +17,7 @@ If this meets your needs, you only need to:
 2. [Report transactions](report-transactions-observer-mode-kmp) from your existing purchase infrastructure to Adapty.
 
 :::tip
-In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: when a user taps the purchase or restore button, the SDK hands the action over to your code so you can perform the purchase or restore yourself. See [Present flows in Observer mode](kmp-present-flows-in-observer-mode).
+In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: register an `AdaptyUIObserverModeResolver` with `setObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button. See [Present flows in Observer mode](kmp-present-flows-in-observer-mode).
 :::
 
 ## Observer mode setup

--- a/src/content/docs/version-3.0/implement-observer-mode-react-native.mdx
+++ b/src/content/docs/version-3.0/implement-observer-mode-react-native.mdx
@@ -13,6 +13,10 @@ If this meets your needs, you only need to:
 1. Turn it on when configuring the Adapty SDK by setting the `observerMode` parameter to `true`. Follow the setup instructions for [React Native](sdk-installation-reactnative).
 2. [Report transactions](report-transactions-observer-mode-react-native) from your existing purchase infrastructure to Adapty.
 
+:::tip
+In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: set the `onObserverPurchaseInitiated` and `onObserverRestoreInitiated` event handlers to perform the purchase or restore with your own code when a user taps the corresponding button. See [Present flows in Observer mode](react-native-present-flows-in-observer-mode).
+:::
+
 ### Observer mode setup
 
 Turn on the Observer mode if you handle purchases and subscription status yourself and use Adapty only for sending subscription events and analytics.

--- a/src/content/docs/version-3.0/implement-observer-mode-unity.mdx
+++ b/src/content/docs/version-3.0/implement-observer-mode-unity.mdx
@@ -14,7 +14,7 @@ If this meets your needs, you only need to:
 2. [Report transactions](report-transactions-observer-mode-unity) from your existing purchase infrastructure to Adapty.
 
 :::tip
-In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: when a user taps the purchase or restore button, the SDK hands the action over to your code so you can perform the purchase or restore yourself. See [Present flows in Observer mode](unity-present-flows-in-observer-mode).
+In SDK v4, you can also present Adapty-rendered flows and paywalls in Observer mode: implement `IAdaptyUIObserverModeResolver` and register it with `SetObserverModeResolver` to perform the purchase or restore with your own code when a user taps the corresponding button. See [Present flows in Observer mode](unity-present-flows-in-observer-mode).
 :::
 
 ### Observer mode setup


### PR DESCRIPTION
Follow-up to the Observer mode terminology work. The `implement-observer-mode` articles for the five cross-platform SDKs each point readers at their "Present flows in Observer mode" guide, but most never named the API the reader actually has to implement — and React Native had no such pointer at all, unlike its four siblings.

## What changed

| Platform | Before | After |
| --- | --- | --- |
| React Native | no tip at all | names `onObserverPurchaseInitiated` / `onObserverRestoreInitiated` |
| Capacitor | generic ("the SDK hands the action over to your code") | names `onObserverPurchaseInitiated` / `onObserverRestoreInitiated` |
| Kotlin Multiplatform | generic | names `AdaptyUIObserverModeResolver` + `setObserverModeResolver` |
| Unity | generic | names `IAdaptyUIObserverModeResolver` + `SetObserverModeResolver` |
| Flutter | named the resolver type only | adds `setObserverModeResolver` for parity |

## Every name was taken from the SDK source

The casing and the mechanism both vary across platforms, so these were verified by grepping each SDK rather than copied from the sibling docs:

- iOS uses `AdaptyObserverModeResolver` — no `UI` infix.
- Android uses `AdaptyUiObserverModeHandler` — lowercase `i`, and it is passed as an argument to `showFlow`, not registered through a setter. There is no `setObserverModeHandler` in the Android source, despite the name being a natural guess.
- Flutter and Kotlin Multiplatform use `AdaptyUIObserverModeResolver` — uppercase `UI` — with `setObserverModeResolver`.
- Unity uses the `IAdaptyUIObserverModeResolver` interface with `SetObserverModeResolver`.
- React Native and Capacitor have no resolver object at all. They use `onObserverPurchaseInitiated` and `onObserverRestoreInitiated` event handlers, which their own present-flows guides call out explicitly as differing from the other platforms.

## iOS and Android are deliberately untouched

My original follow-up note claimed these two already had handler prose and the other five lacked it. That was wrong, and it is worth correcting here because it changes the scope.

Neither iOS nor Android has such a tip — but for them that is correct rather than a gap. Observer-mode presentation predates SDK v4 on the native SDKs; the React Native and Capacitor present-flows guides state that the capability "was available only in the native iOS and Android SDKs" before 4.0. So the "In SDK v4, you can also…" framing that carries this prose on the five cross-platform SDKs does not apply to iOS or Android, which is why they never had it. Adding it there would introduce a false version constraint.

The three articles whose tips already linked their present-flows guide keep that link — unlike the Flutter case fixed in the previous PR, those tips sit near the top of the article, far from the section link, so they are a useful forward pointer rather than an adjacent duplicate.

## Verification

- `check-mdx-parse` (6034 files) and `lint-mdx` clean; `lint-prose` reports nothing on the five edited files.
- `check-links`: 0 broken internal links, with no observer-mode article appearing in the report.
- Each API name was additionally confirmed to appear in that platform's own present-flows article, so the tip and the guide it points at agree.
- Broken external URLs in the report are pre-existing or flaky (23 timeouts, 6 `swift.adapty.io` 404s in the unmaintained `*-sdk-models` articles, one archive 503). This branch adds no external URLs.

## Placement

Flutter's tip used to sit at the end of its article while the other four sat just below the intro list. It now sits in the same slot as the rest, so all five articles carry this prose in one predictable place.

That move is split across two commits so neither hides the other:

1. The tip is relocated **verbatim** — byte-identical text, no rewording.
2. The `See [Present flows in Observer mode]` sentence is restored. It was dropped in the previous PR because it duplicated the section link two lines below; at the top of the article it is a forward pointer instead of an adjacent duplicate, which is exactly why the other four kept theirs.

All five tips are now identical in shape: same sentence frame, same slot before the "Observer mode setup" heading, each naming its own platform's API and linking its own present-flows guide.
