### PR TITLE
Replace hand-pasted YouTube iframes with a <YouTube> component

### DIFF
--- a/scripts/generate-md.mjs
+++ b/scripts/generate-md.mjs
@@ -112,6 +112,14 @@ function stripContent(content, reusableComponents) {
     // Remove wrapping Zoom: <Zoom>...</Zoom> (keep content)
     processed = processed.replace(/<Zoom>(.*?)<\/Zoom>/gs, '$1');
 
+    // Drop YouTube embeds — a bare iframe URL teaches a plain-text reader
+    // nothing. Three forms are matched: the <YouTube /> component, and the
+    // div-wrapped and bare iframes that predate it, which src/locales still
+    // carries until each file is retranslated from its English source.
+    processed = processed.replace(/<YouTube\b[^>]*\/>/g, '');
+    processed = processed.replace(/<div[^>]*>\s*<iframe\b[^>]*youtube\.com\/embed[\s\S]*?<\/div>/g, '');
+    processed = processed.replace(/<iframe\b[^>]*youtube\.com\/embed[\s\S]*?(?:<\/iframe>|\/>)/g, '');
+
     // Replace Inline icon component with its alt text: <Inline id="..." alt="Edit" ... /> → Edit
     processed = processed.replace(/<Inline\s+[^>]*alt="([^"]*)"[^>]*\/>/g, '$1');
     processed = processed.replace(/<Inline\s+[^>]*\/>/g, '');

--- a/scripts/generate-platform-llms-full.mjs
+++ b/scripts/generate-platform-llms-full.mjs
@@ -103,6 +103,14 @@ function stripContent(content, reusableComponents) {
 
     // 2. Remove Zoom and ZoomImage tags
     processed = processed.replace(/<ZoomImage\s+[^>]*\/>/g, '');
+
+    // Drop YouTube embeds — a bare iframe URL teaches a plain-text reader
+    // nothing. Three forms are matched: the <YouTube /> component, and the
+    // div-wrapped and bare iframes that predate it, which src/locales still
+    // carries until each file is retranslated from its English source.
+    processed = processed.replace(/<YouTube\b[^>]*\/>/g, '');
+    processed = processed.replace(/<div[^>]*>\s*<iframe\b[^>]*youtube\.com\/embed[\s\S]*?<\/div>/g, '');
+    processed = processed.replace(/<iframe\b[^>]*youtube\.com\/embed[\s\S]*?(?:<\/iframe>|\/>)/g, '');
     processed = processed.replace(/<Zoom>(.*?)<\/Zoom>/gs, '$1');
 
     // Replace Inline icon component with its alt text: <Inline id="..." alt="Edit" ... /> → Edit

--- a/src/components/YouTube.astro
+++ b/src/components/YouTube.astro
@@ -1,0 +1,102 @@
+---
+/**
+ * YouTube embed — responsive 16:9, centred, capped at `width`.
+ *
+ * Use it instead of YouTube's own copy-paste snippet, which hard-codes
+ * 560×315 and so overflows the column on narrow screens. The wrapper is an
+ * aspect-ratio box and the iframe fills it absolutely: `aspect-ratio` alone
+ * does not constrain a replaced element that carries its own width and height,
+ * which is why the box-plus-absolute-fill pattern is needed rather than a
+ * single styled iframe.
+ *
+ * `id` takes the bare 11-character video ID or any YouTube link you can paste:
+ *
+ *   <YouTube id="uicKwOak-Zo" />
+ *   <YouTube id="https://www.youtube.com/watch?v=uicKwOak-Zo" />   address bar
+ *   <YouTube id="https://youtu.be/uicKwOak-Zo?si=9c_a5eHpr" />     share dialog
+ *   <YouTube id="https://www.youtube.com/embed/uicKwOak-Zo" />     embed dialog
+ *
+ * Query parameters are dropped, `?si=` included — that token is share-link
+ * attribution and has no effect on playback.
+ */
+interface Props {
+  /** Video ID, or any YouTube URL. */
+  id: string;
+  /** iframe title, announced by screen readers. Name the video where you can. */
+  title?: string;
+  /** Max width of the player. The 16:9 box shrinks below this on narrow screens. */
+  width?: string;
+}
+
+const { id, title = 'YouTube video player', width = '560px' } = Astro.props;
+
+/** YouTube IDs are exactly 11 characters of [A-Za-z0-9_-]. */
+const ID_PATTERN = /^[\w-]{11}$/;
+
+function extractVideoId(value: string): string | undefined {
+  const raw = (value ?? '').trim();
+  if (!raw) return undefined;
+  if (ID_PATTERN.test(raw)) return raw;
+
+  let url: URL;
+  try {
+    // Tolerate a pasted link with no scheme (`youtu.be/ID`).
+    url = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`);
+  } catch {
+    return undefined;
+  }
+
+  const host = url.hostname.replace(/^www\./, '');
+  let candidate: string | null = null;
+
+  if (host === 'youtu.be') {
+    candidate = url.pathname.slice(1);
+  } else if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'youtube-nocookie.com') {
+    if (url.pathname === '/watch') {
+      candidate = url.searchParams.get('v');
+    } else {
+      // /embed/ID, /shorts/ID, /live/ID, /v/ID
+      candidate = url.pathname.match(/^\/(?:embed|shorts|live|v)\/([^/?#]+)/)?.[1] ?? null;
+    }
+  }
+
+  return candidate && ID_PATTERN.test(candidate) ? candidate : undefined;
+}
+
+const videoId = extractVideoId(id);
+---
+
+{videoId ? (
+  <div class="youtube-embed" style={{ maxWidth: width }}>
+    <iframe
+      src={`https://www.youtube.com/embed/${videoId}`}
+      title={title}
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      referrerpolicy="strict-origin-when-cross-origin"
+      loading="lazy"
+      allowfullscreen
+    ></iframe>
+  </div>
+) : (
+  <div class="p-4 border border-red-200 bg-red-50 text-red-600 rounded-md text-sm">
+    Not a YouTube video: <code>{id}</code>
+  </div>
+)}
+
+<style>
+  .youtube-embed {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    margin: 0 auto 2rem;
+  }
+
+  .youtube-embed iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+</style>

--- a/src/components/mdxComponents.ts
+++ b/src/components/mdxComponents.ts
@@ -19,6 +19,7 @@ import Details from './Details.astro';
 import InlineTooltip from './InlineTooltip.astro';
 import ZoomImage from './ZoomImage.astro';
 import DocVideo from './DocVideo.astro';
+import YouTube from './YouTube.astro';
 import Button from './Button.astro';
 import Inline from './Inline.astro';
 import MDXImage from './MDXImage.astro';
@@ -39,6 +40,7 @@ export const mdxComponents = {
   InlineTooltip,
   ZoomImage,
   DocVideo,
+  YouTube,
   MDXImage,
   Button,
   Inline,

--- a/src/content/docs/guides/flow-builder/adapty-flow-builder.mdx
+++ b/src/content/docs/guides/flow-builder/adapty-flow-builder.mdx
@@ -22,29 +22,7 @@ In Adapty, you can create flows in a visual no-code editor.
 - **Native rendering**: The Adapty SDK renders flows natively without web views to ensure a seamless user experience.
 - **Update without redeploying**: Change copy, design, or logic any time. Updates reach your users without an app release.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/8Cby6lVGI0o?si=rYA1HtdayyF1ffWd"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="8Cby6lVGI0o" />
 
 ## What you can build
 

--- a/src/content/docs/guides/flow-builder/builder-containers.mdx
+++ b/src/content/docs/guides/flow-builder/builder-containers.mdx
@@ -20,29 +20,7 @@ Layout elements group other elements together and control how they're laid out o
 **Tabs** also fall under this umbrella, but live in a separate article. See [Tabs](builder-tabs) for details.
 :::
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/ZlI-1D1a0cU?si=F0Kqf9EmyvwcQMp8"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="ZlI-1D1a0cU" />
 
 ## Containers
 

--- a/src/content/docs/guides/flow-builder/builder-element-states.mdx
+++ b/src/content/docs/guides/flow-builder/builder-element-states.mdx
@@ -9,29 +9,7 @@ import ZoomImage from '@site/src/components/ZoomImage.astro';
 
 Interactive flow elements change their look based on user actions: a tapped quiz option becomes **Selected**, a focused input becomes **Active**. Some states are condition-driven — for example, you can **disable** a button. Style each state separately to give users visual feedback without app code.
 
-<div style={{
-  maxWidth: '560px',
-  margin: '0 auto 2rem',
-  position: 'relative',
-  aspectRatio: '16/9',
-  width: '100%'
-}}>
-  <iframe
-    style={{
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: '100%',
-      height: '100%'
-    }}
-    src="https://www.youtube.com/embed/gdsNfHpKAqQ?si=VY5mqZgH1j0RB6fE"
-    title="YouTube video player"
-    frameBorder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    referrerPolicy="strict-origin-when-cross-origin"
-    allowFullScreen
-  />
-</div>
+<YouTube id="gdsNfHpKAqQ" />
 
 
 ## Available states by element kind

--- a/src/content/docs/guides/flow-builder/builder-styling.mdx
+++ b/src/content/docs/guides/flow-builder/builder-styling.mdx
@@ -27,29 +27,7 @@ The **Visibility** toggle determines whether the element appears on screen.
 * <Inline id="visibility-conditional.svg" alt="Conditional" /> **Conditional**: The element is visible only when specific conditions are met. See [Conditional visibility](onboarding-element-visibility) for more information.
 * <Inline id="visibility-hide.svg" alt="Hide" /> **Hide**: The element is always hidden. Use this to temporarily remove an element from the flow without deleting it.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/3w3YSOmI3tQ?si=vPhoQGt44SI285Ru"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="3w3YSOmI3tQ" />
 
 ## Fill
 
@@ -238,29 +216,7 @@ A few elements expose state-specific styling outside the standard **Default / Se
 
 The **Styles** <Inline id="styles.svg" alt="Styles" /> panel in the left sidebar allows you to define reusable styles that apply across your entire flow. Two types of styles are available: text styles and color styles. You need to use color styles to enable dark mode support.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/auMs_Tr9xtU?si=Ti7fZbZpbd0p_XEO"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="auMs_Tr9xtU" />
 
 ### Text styles
 

--- a/src/content/docs/guides/flow-builder/builder-ui.mdx
+++ b/src/content/docs/guides/flow-builder/builder-ui.mdx
@@ -8,29 +8,7 @@ import ZoomImage from '@site/src/components/ZoomImage';
 
 The main Flow Builder UI includes all the tools necessary to add visual elements, edit their properties, and change the logic of the user flow. This article covers each area of the interface: what it does and where to find it.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/n0uV44q318o?si=sbJwE33yJWxbbEE1"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="n0uV44q318o" />
 
 <FlowVideoTutorials />
 

--- a/src/content/docs/guides/flow-builder/flow-builder-recipes.mdx
+++ b/src/content/docs/guides/flow-builder/flow-builder-recipes.mdx
@@ -12,28 +12,6 @@ This section walks through how to build the most common screen templates in the 
 
 Follow this quickstart video to create a basic personalized flow:
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/aa-m459VIuY?si=zN_Co6B6qB88UPZP"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="aa-m459VIuY" />
 
 <FlowVideoTutorials />

--- a/src/content/docs/guides/flow-builder/migrate-to-flows.mdx
+++ b/src/content/docs/guides/flow-builder/migrate-to-flows.mdx
@@ -18,29 +18,7 @@ This guide explains what changes when you move to flows, and how to roll the cha
 Flows require Adapty SDK v4.0 or later.
 :::
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/8Cby6lVGI0o?si=rYA1HtdayyF1ffWd"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="8Cby6lVGI0o" />
 
 ## Flows vs. onboardings and paywalls
 

--- a/src/content/docs/guides/flow-builder/onboarding-flow-tutorial.mdx
+++ b/src/content/docs/guides/flow-builder/onboarding-flow-tutorial.mdx
@@ -17,29 +17,7 @@ The same pattern applies to any flow that personalizes content based on user inp
 
 Prefer the video format? This quickstart tutorial walks through the same process, end to end:
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/aa-m459VIuY?si=zN_Co6B6qB88UPZP"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="aa-m459VIuY" />
 
 ## Before you start
 

--- a/src/content/docs/kmp/kmp-sdk-overview.mdx
+++ b/src/content/docs/kmp/kmp-sdk-overview.mdx
@@ -43,7 +43,7 @@ Want to see how it all comes together? We've got you covered:
 - **Sample app**: Check out our [complete example](https://github.com/adaptyteam/AdaptySDK-KMP/tree/main/example) that demonstrates the full setup
 - **Video tutorial**: Follow along with our step-by-step implementation video below
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/JfwJvwnloNw?si=HskPxRk4WGkF_u9s" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<YouTube id="JfwJvwnloNw" />
 
 ## Main concepts
 

--- a/src/content/docs/react-native/react-native-sdk-overview.mdx
+++ b/src/content/docs/react-native/react-native-sdk-overview.mdx
@@ -45,9 +45,7 @@ Want to see how it all comes together? We've got you covered:
 - **Sample apps**: Check out our [complete examples](https://github.com/adaptyteam/AdaptySDK-React-Native/tree/master/examples) that demonstrate the full setup
 - **Video tutorial**: Follow along with our step-by-step implementation video below
 
-<div style={{ textAlign: 'center' }}>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/TtCJswpt2ms?si=FlFJGvpj-U33yoNK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-</div>
+<YouTube id="TtCJswpt2ms" />
 
 ## Main concepts
 

--- a/src/content/docs/version-3.0/app-store-connection-configuration.mdx
+++ b/src/content/docs/version-3.0/app-store-connection-configuration.mdx
@@ -8,29 +8,7 @@ import Zoom from 'react-medium-image-zoom';
 import 'react-medium-image-zoom/dist/styles.css';
 import ProvideBundleID from '@site/src/components/reusable/ProvideBundleID.md';
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/VJQbzoTCkqs?si=l7BPX9mIu6GVGZ0Z"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="VJQbzoTCkqs" />
 
 This section describes how to establish the connection between the App Store and Adapty for your iOS app. This is required for us to be able to show subscription analytics and validate purchases. You can complete the integration during the initial onboarding or later in the **App Settings** within the Adapty Dashboard.
 

--- a/src/content/docs/version-3.0/autopilot.mdx
+++ b/src/content/docs/version-3.0/autopilot.mdx
@@ -8,29 +8,7 @@ import ZoomImage from '@site/src/components/ZoomImage.astro';
 
 Growth Advisor is an AI-powered growth tool for subscription apps. It builds a long-term plan to increase your revenue through A/B tests, informed by market data from over 20 thousand apps tracked by Adapty.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/xxp-H_hzEPA?si=kEbAHsTOTwsAZNsm"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="xxp-H_hzEPA" />
 
 ## Prerequisites
 

--- a/src/content/docs/version-3.0/create-product.mdx
+++ b/src/content/docs/version-3.0/create-product.mdx
@@ -25,29 +25,7 @@ Before you start, ensure you've configured the integration with the stores you n
 If you configured the App Store integration some time ago, ensure you've [added the App Store Connect API key](app-store-connection-configuration#step-6-add-app-store-connect-api-key) as well.
 :::
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/qUpC2XG-r5E?si=7Komyv4_PUQ4FaEH"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="qUpC2XG-r5E" />
 
 To add a new product to your app:
 
@@ -174,29 +152,7 @@ Before you start, ensure you've:
 **If you don't have any products created**, consider following the [Push to stores](#create-product-and-push-to-store) guide, so you create them both in Adapty and stores at the same time.
 :::
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/nlkdKCF0SwY?si=VVigzHcpv3waKJmI"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="nlkdKCF0SwY" />
 
 To add a new product to your app:
 

--- a/src/content/docs/version-3.0/enabling-of-devepoler-api.mdx
+++ b/src/content/docs/version-3.0/enabling-of-devepoler-api.mdx
@@ -4,29 +4,7 @@ description: "Enable the three Google APIs Adapty calls to read your products, v
 metadataTitle: "Enable Developer APIs in Google Cloud | Adapty Docs"
 ---
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/7dN50n5bcLc?si=c2znttIb--4VcrRO"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="7dN50n5bcLc" />
 
 Adapty reads your products, validates purchases, and receives subscription events through the following Google APIs:
 

--- a/src/content/docs/version-3.0/flow-selectable-elements.mdx
+++ b/src/content/docs/version-3.0/flow-selectable-elements.mdx
@@ -24,29 +24,7 @@ Some element types are selectable by default — they already belong to auto-cre
 
 ## Make an element selectable
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/btpZPOm9VRY?si=1P959iwNfIJ1ZP7N"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="btpZPOm9VRY" />
 
 In some cases, you might want to make additional elements selectable. For example, you can add a **Don't ask me again** checkbox that operates as an element inside a quiz group.
 

--- a/src/content/docs/version-3.0/initial-android.mdx
+++ b/src/content/docs/version-3.0/initial-android.mdx
@@ -12,29 +12,7 @@ Each store is connected separately, and these connections are independent. If yo
 
 The setup takes about an hour. The built-in onboarding in the Adapty Dashboard covers the same ground if you prefer to stay in one window.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/7dN50n5bcLc?si=c2znttIb--4VcrRO"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="7dN50n5bcLc" />
 
 ## Before you start
 

--- a/src/content/docs/version-3.0/initial_ios.mdx
+++ b/src/content/docs/version-3.0/initial_ios.mdx
@@ -13,29 +13,7 @@ Each store is connected separately, and Adapty validates purchases only for the 
 
 The setup spans App Store Connect and the Adapty Dashboard, and takes about 30 minutes. The built-in onboarding in the Adapty Dashboard covers the same ground if you prefer to stay in one window.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/VJQbzoTCkqs?si=l7BPX9mIu6GVGZ0Z"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="VJQbzoTCkqs" />
 
 ## Guide for the initial integration
 

--- a/src/content/docs/version-3.0/manage-paywall-ui-elements.mdx
+++ b/src/content/docs/version-3.0/manage-paywall-ui-elements.mdx
@@ -21,56 +21,12 @@ For visual properties like fill, borders, and effects, see [Styles and appearanc
 <Tabs groupId="video">
     <TabItem value="align" label="Alignment & positioning">
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/aRS4Bzb6W4I?si=qH7B6t3kMab70gBi"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="aRS4Bzb6W4I" />
 
     </TabItem>
     <TabItem value="layout" label="Layout, sizing & spacing">
 
-        <div style={{
-            maxWidth: '560px',
-            margin: '0 auto 2rem',
-            position: 'relative',
-            aspectRatio: '16/9',
-            width: '100%'
-        }}>
-            <iframe
-                style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: '100%',
-                    height: '100%'
-                }}
-                src="https://www.youtube.com/embed/WQ9fpxrndok?si=ROMdIPvJ32tSwUX6"
-                title="YouTube video player"
-                frameBorder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                referrerPolicy="strict-origin-when-cross-origin"
-                allowFullScreen
-            />
-        </div>
+        <YouTube id="WQ9fpxrndok" />
 
     </TabItem>
 </Tabs>

--- a/src/content/docs/version-3.0/migration-to-ios330.mdx
+++ b/src/content/docs/version-3.0/migration-to-ios330.mdx
@@ -17,18 +17,7 @@ Adapty SDK 3.3.0 is a major release that brought some improvements which however
 6. Update integration configurations for Adjust, AirBridge, Amplitude, AppMetrica, Appsflyer, Branch, Facebook Ads, Firebase and Google Analytics, Mixpanel, OneSignal, Pushwoosh.
 7. Update Observer mode implementation.
 
-<div style={{ textAlign: 'center' }}>
-  <iframe 
-    width="560" 
-    height="315" 
-    src="https://www.youtube.com/embed/9Xs8d0lt_RY?si=xvWhUO2tlG1tKP5f" 
-    title="YouTube video player" 
-    frameborder="0" 
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-    referrerpolicy="strict-origin-when-cross-origin" 
-    allowfullscreen>
-  </iframe>
-</div>
+<YouTube id="9Xs8d0lt_RY" />
 
 ## Rename Adapty.Configuration to AdaptyConfiguration
 

--- a/src/content/docs/version-3.0/onboarding-actions.mdx
+++ b/src/content/docs/version-3.0/onboarding-actions.mdx
@@ -97,29 +97,7 @@ This action overrides the initial state set in **Visibility** in the **Design** 
 A **Show** or **Hide** action with no target element [blocks previewing and publishing](flow-common-issues#a-flow-wont-preview-or-publish). Select a target or remove the action.
 :::
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/3w3YSOmI3tQ?si=vPhoQGt44SI285Ru"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="3w3YSOmI3tQ" />
 
 ### Show alert
 
@@ -241,29 +219,7 @@ This way, your app controls the transition based on the actual result, instead o
 
 ## Conditional actions
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/xmWSEPxnI0s?si=mazHQHE89qEDxvPA"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="xmWSEPxnI0s" />
 
 Use conditional actions to split the flow into different paths based on user data.
 

--- a/src/content/docs/version-3.0/onboarding-element-visibility.mdx
+++ b/src/content/docs/version-3.0/onboarding-element-visibility.mdx
@@ -4,29 +4,7 @@ description: "Show or hide elements based on conditions."
 metadataTitle: "Conditionals | Flow Builder | Adapty Docs"
 ---
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/3w3YSOmI3tQ?si=vPhoQGt44SI285Ru"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="3w3YSOmI3tQ" />
 
 You can control whether an element appears by adding a condition to it. A conditional element is only visible to users who meet the specified criteria.
 

--- a/src/content/docs/version-3.0/onboarding-navigation-branching.mdx
+++ b/src/content/docs/version-3.0/onboarding-navigation-branching.mdx
@@ -10,29 +10,7 @@ Navigation and branching lets you guide users through every step of your flow: u
 Navigation is an action type. To learn more about actions, see [Actions](onboarding-actions).
 :::
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/OLl-WziDMhU?si=_eUtsmbEuFAaLj1r"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="OLl-WziDMhU" />
 
 ## Navigate between screens
 

--- a/src/content/docs/version-3.0/onboarding-quizzes.mdx
+++ b/src/content/docs/version-3.0/onboarding-quizzes.mdx
@@ -6,29 +6,7 @@ metadataTitle: "Flow quizzes | Adapty Docs"
 
 Use quizzes to present users with predefined choices. Unlike inputs, quizzes don't have typed fields — users select from the options you define. Use them to collect preferences, segment users, or branch the flow based on their answers.
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/o27JCZpziVo?si=rooiCS91W0yIBgkz"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="o27JCZpziVo" />
 
 ### Add a quiz
 

--- a/src/content/docs/version-3.0/paywall-product-block.mdx
+++ b/src/content/docs/version-3.0/paywall-product-block.mdx
@@ -12,29 +12,7 @@ To set up purchases on a screen, add a purchase button and configure its **Purch
   Ask the AI Editor to break the annual plan down to a daily cost, cross out the old price, or mark the best value. It restyles the product cards on this screen — never your catalog or prices.
 </AIPromo>
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/LLIZCd94PlE?si=t_8BitA1FBpbd8ue"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="LLIZCd94PlE" />
 
 ## Add products
 

--- a/src/content/docs/version-3.0/quickstart-paywalls.mdx
+++ b/src/content/docs/version-3.0/quickstart-paywalls.mdx
@@ -79,29 +79,7 @@ Adapty lets you show different flows to various user groups and analyze performa
 </TabItem>
 <TabItem value="manual-paywall" label="Implement paywall manually">
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/e4o7Z2tUGL8?si=ipwbW3VVN0fIg0R0"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="e4o7Z2tUGL8" />
 
 A paywall is a remotely configured container for one or more products. Adapty serves the product list and an optional [remote config](customize-paywall-with-remote-config) JSON payload — your app code reads them and draws the UI.
 

--- a/src/content/docs/version-3.0/quickstart-products.mdx
+++ b/src/content/docs/version-3.0/quickstart-products.mdx
@@ -24,57 +24,13 @@ Let's add your first product.
 
 <TabItem value="no-products" label="No products in stores yet" default>
 
-<div style={{
-  maxWidth: '560px',
-  margin: '0 auto 2rem',
-  position: 'relative',
-  aspectRatio: '16/9',
-  width: '100%'
-}}>
-  <iframe
-    style={{
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: '100%',
-      height: '100%'
-    }}
-    src="https://www.youtube.com/embed/qUpC2XG-r5E?si=7Komyv4_PUQ4FaEH"
-    title="YouTube video player"
-    frameBorder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    referrerPolicy="strict-origin-when-cross-origin"
-    allowFullScreen
-  />
-</div>
+<YouTube id="qUpC2XG-r5E" />
 
 </TabItem>
 
 <TabItem value="products-in-stores" label="Products in stores already">
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/nlkdKCF0SwY?si=VVigzHcpv3waKJmI"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="nlkdKCF0SwY" />
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/version-3.0/sdk-installation-ios.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-ios.mdx
@@ -28,15 +28,11 @@ For a complete implementation walkthrough, you can also see the videos:
 <Tabs groupId="current-os" queryString>
 <TabItem value="swiftui" label="iOS (SwiftUI)" default>
 
-<div style={{ textAlign: 'center' }}>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/cSChHc8k2zA?si=KhNFhqXccIzYwTcm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-</div>
+<YouTube id="cSChHc8k2zA" />
 </TabItem>
 <TabItem value="uikit" label="iOS (UIKit)" default>
 
-<div style={{ textAlign: 'center' }}>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/WEUnlaAjSI0?si=sjXKVVb56tEHDKzJ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-</div>
+<YouTube id="WEUnlaAjSI0" />
 </TabItem>
 </Tabs>
 

--- a/src/content/docs/version-3.0/sdk-installation-kotlin-multiplatform.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-kotlin-multiplatform.mdx
@@ -23,7 +23,7 @@ Want to see a real-world example of how Adapty SDK is integrated into a mobile a
 
 For a complete implementation walkthrough, you can also see the video:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/JfwJvwnloNw?si=HskPxRk4WGkF_u9s" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<YouTube id="JfwJvwnloNw" />
 
 ## Requirements
 

--- a/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
+++ b/src/content/docs/version-3.0/sdk-installation-react-native-expo.mdx
@@ -33,9 +33,7 @@ Want to see a real-world example of how Adapty SDK is integrated into an Expo ap
 :::
 
 For a complete implementation walkthrough, you can also see the video:
-<div style={{ textAlign: 'center' }}>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/TtCJswpt2ms?si=FlFJGvpj-U33yoNK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-</div>
+<YouTube id="TtCJswpt2ms" />
 
 ## Requirements
 

--- a/src/content/docs/version-3.0/test-purchases-in-sandbox.mdx
+++ b/src/content/docs/version-3.0/test-purchases-in-sandbox.mdx
@@ -24,29 +24,7 @@ To proceed with in-app purchases testing, make sure:
 
 ## Sandbox testing
 
-<div style={{
-    maxWidth: '560px',
-    margin: '0 auto 2rem',
-    position: 'relative',
-    aspectRatio: '16/9',
-    width: '100%'
-}}>
-    <iframe
-        style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%'
-        }}
-        src="https://www.youtube.com/embed/hq4PRU-vuik?si=m5F5Sj6iLEJ-2q6n"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-    />
-</div>
+<YouTube id="hq4PRU-vuik" />
 
 :::info
 We recommend testing in-app purchases with a real device. While sandbox purchases can run on simulators, real devices are needed to fully test all flows, including payment dialogs and biometric prompts.


### PR DESCRIPTION
## Why

Adding a video to the docs meant finding an article that already had one, copying its 18-line responsive wrapper, and swapping the URL. Six embeds skipped that and kept YouTube's own `560×315` snippet, which doesn't scale on narrow screens.

## What

A new `src/components/YouTube.astro`, and all 36 existing embeds migrated to it.

```mdx
<YouTube id="uicKwOak-Zo" />
```

`id` accepts the bare video ID **or** any YouTube link you can paste — address bar (`watch?v=`), share dialog (`youtu.be/…?si=`), embed dialog (`/embed/…`), or Shorts. Query parameters are dropped, `?si=` included: that token is share-link attribution and has no effect on playback. Optional `title` (defaults to `"YouTube video player"`, what all 36 embeds used) and `width` (defaults to `560px`).

Registration is one entry in `mdxComponents.ts` — the map both the English and localized routes spread — so the routes can't drift apart.

## Rendering

Unchanged for the 29 embeds that already used the responsive wrapper. The other 7 become responsive, which is the point of the change.

## Export scripts

`stripContent` in `generate-md.mjs` and `generate-platform-llms-full.mjs` now drops video embeds. This fixes a pre-existing leak as well as covering the new component: neither script had an iframe rule, so raw JSX embed blocks were reaching the `.md` and `llms` exports as literal markup. The rule also matches the old div-wrapped and bare-iframe forms, which `src/locales` still carries — 212 locale files — until each is retranslated from its English source. Those locale files are deliberately not edited by hand.

## Verification

- `check-mdx-parse` — 6034 files parse cleanly
- `lint-mdx` — all files OK
- Export sweep — 242 files containing embeds strip to zero leaks, with no over-stripping of surrounding prose
- Browser — a top-of-article embed, a pair inside `<Tabs>`, and one nested in a `<TabItem>` all render as a centred 16:9 box