### PR TITLE
Add a youtube-video skill, and the Interaction basics video

### DIFF
--- a/.claude/skills/youtube-video/SKILL.md
+++ b/.claude/skills/youtube-video/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: youtube-video
+description: Use when the user gives one or more YouTube links to publish in the docs — any link shape, embed/watch/share/Shorts. Finds the article each video belongs in, inserts a <YouTube> embed at the right spot, and opens a PR.
+---
+
+# Publish a YouTube video into the docs
+
+## Overview
+
+The user drops a YouTube link. This skill decides **which article the video belongs in**, puts a `<YouTube>` embed in the **right place inside that article**, and opens a PR.
+
+Usually one article. Occasionally two or three — a video about a concept that genuinely spans them. Never "everything the description links to."
+
+## Input
+
+Any YouTube link shape, or a bare video ID:
+
+```
+https://www.youtube.com/embed/uicKwOak-Zo?si=9c_a5eHprETb1L_O
+https://www.youtube.com/watch?v=uicKwOak-Zo
+https://youtu.be/uicKwOak-Zo?si=9c_a5eHprETb1L_O
+uicKwOak-Zo
+```
+
+Several at once is fine — run the workflow per video, then batch the result into one PR.
+
+If the user gives no link, ask for one in plain prose. Don't open an `AskUserQuestion` form; they want to paste a URL, not pick from options.
+
+## Step 1 — Fetch the metadata
+
+```bash
+node .claude/skills/youtube-video/yt-meta.mjs <url-or-id>
+```
+
+Returns JSON: `id`, `title`, `channel`, `watchUrl`, `description`, `docsLinks`, `warnings`.
+
+**Do not use WebFetch for this.** YouTube serves it a navigation-only shell with no title and no description; it returns a confident-sounding "the page doesn't contain that information."
+
+**If `warnings` is non-empty, stop and read it.** The usual case is that YouTube changed its watch-page markup and the description could not be read. The title alone is not enough to place a video — ask the user to paste the description rather than proceeding on a guess.
+
+## Step 2 — Treat `docsLinks` as candidates, not as the answer
+
+Video descriptions carry a `Docs:` block of **related reading**. It is not a placement instruction. "Interaction basics" lists five articles and belongs in one of them.
+
+So: use `docsLinks` to seed the candidate set, then decide properly. Also consider articles the description does *not* link — a description can simply be missing the right one.
+
+## Step 3 — Find the owning article
+
+**Use the `context-mill` skill in lookup mode.** Per CLAUDE.md, do not `grep`, `find`, or `glob` the docs to find the right article, and do not read sidebar JSON to find it either. Zone briefs carry what search can't: which article **owns** a topic and where the boundary against a neighbouring zone falls.
+
+The question to answer is ownership, not relevance:
+
+> If a reader had exactly one question this video answers, which article would they land on?
+
+Signals that an article is the owner:
+
+- Its scope **is** the video's subject, not a neighbour that mentions it.
+- Its headings match what the video walks through.
+- It's where the concept is *defined*, not where it's *referenced*.
+
+Signals it is not:
+
+- It links to the real owner for this concept.
+- It already carries its own video on its own subject — a second, unrelated video buries both.
+- It's a platform-specific SDK page and the video is builder/dashboard work (or the reverse).
+
+Resolve a candidate slug to a file by filename — URLs derive from filename alone, not folder path, so `onboarding-actions` is `src/content/docs/**/onboarding-actions.mdx` wherever it sits. Watch for `customSlug` frontmatter overriding the URL.
+
+## Step 4 — Check what's already there
+
+Before proposing anything:
+
+- **Is this video already in the article?** Grep the target file for the video ID. If present, report it and change nothing — re-running is not supposed to duplicate.
+- **What videos does the article already carry?** More than two embeds in one article is a signal to reconsider, not a reason to stop.
+- **Is the video already elsewhere in the docs?** The same video legitimately appears in two articles (`8Cby6lVGI0o` is in both `adapty-flow-builder` and `migrate-to-flows`). Worth knowing, not disqualifying.
+
+## Step 5 — Decide placement inside the article
+
+Read off the existing embeds:
+
+| Video scope | Goes |
+|---|---|
+| The article's whole subject | Top of the article — after the intro paragraph, before the first `##` |
+| One section's subject | Directly under that `##`/`###` heading, after the section's first paragraph |
+
+Never above the intro paragraph: articles open with prose, not media, and the intro has no heading of its own.
+
+Leave one blank line either side. Match the surrounding indentation — inside a `<TabItem>`, the embed indents with its siblings.
+
+## Step 6 — Propose, then stop
+
+Print the proposal and **wait for confirmation before editing anything**:
+
+```
+Video:      "Interaction basics" (uicKwOak-Zo)
+Docs links in description: 5
+
+Proposed:   src/content/docs/version-3.0/onboarding-actions.mdx
+            under "## Trigger types", after the intro sentence
+Because:    <one line on why this article owns the topic>
+
+Rejected:   onboarding-element-visibility — already carries 3w3YSOmI3tQ on its own subject
+            onboarding-variables         — video covers variables only in passing
+            ...
+```
+
+Name the rejected candidates with reasons. A silent choice among five is unreviewable.
+
+## Step 7 — Insert
+
+```mdx
+<YouTube id="uicKwOak-Zo" title="Interaction basics" />
+```
+
+Pass `title` — it's the iframe's accessible name, and "YouTube video player" tells a screen-reader user nothing. Write the bare video ID, never the full URL: the component accepts URLs so a hand-paste can't break, but the committed repo stays uniform.
+
+**Edit only the English source** in `src/content/docs/`. Never touch `src/locales/` — those are regenerated by the translation workflow on push to main.
+
+**Don't add `keywords`** to the article's frontmatter, and don't touch any other frontmatter.
+
+## Step 8 — Verify
+
+```bash
+node scripts/check-mdx-parse.mjs && node scripts/lint-mdx.mjs
+```
+
+Both must pass. Do **not** run `npm run build` — it exhausts memory on this repo.
+
+## Step 9 — Open the PR
+
+```bash
+git checkout -b docs/<short-video-slug> --no-track
+```
+
+`--no-track` matters: a tracking branch has previously caused a push to land on main.
+
+Commit, push, `gh pr create`. In the PR body say which article, why that one, and what was rejected — the same content as the Step 6 proposal, which is the part a reviewer needs.
+
+No Jira, Slack, other PR, or source-repo links in the PR body. No `Co-Authored-By` trailer.
+
+## Edge cases
+
+**Video belongs in more than one article.** Legitimate when both articles genuinely own part of the subject. Propose all of them in one proposal with a reason each; don't split into separate PRs.
+
+**No good home.** Say so, and say what would need to exist. Do not park the video in the nearest loosely-related article — an embed in the wrong place is worse than none, because it looks deliberate.
+
+**Description links no docs at all.** Fine. Fall back to `context-mill` on the title and description text.
+
+**Video supersedes one already in the article.** Ask. Replacing is a content decision, not a mechanical one.

--- a/.claude/skills/youtube-video/yt-meta.mjs
+++ b/.claude/skills/youtube-video/yt-meta.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+//
+// Fetch a YouTube video's title and description, and pull the docs links out of
+// the description.
+//
+//   node .claude/skills/youtube-video/yt-meta.mjs <url-or-id> [more...]
+//
+// WebFetch cannot do this job: YouTube serves it a navigation-only shell with
+// no title and no description. Two sources are used instead —
+//
+//   * oEmbed, a small documented JSON endpoint, for the title and channel;
+//   * the watch page's embedded player JSON for `shortDescription`, which is
+//     the only place the full description is available without an API key.
+//
+// The second source is undocumented and can break. When it does, the title
+// still resolves and the failure is reported in `warnings` rather than being
+// passed off as an empty description — a video placed on the strength of a
+// silently-empty description would land in the wrong article.
+
+const ID_PATTERN = /^[\w-]{11}$/;
+
+/** Accepts a bare ID or any YouTube URL. Mirrors src/components/YouTube.astro. */
+export function extractVideoId(value) {
+  const raw = (value ?? '').trim();
+  if (!raw) return undefined;
+  if (ID_PATTERN.test(raw)) return raw;
+
+  let url;
+  try {
+    url = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`);
+  } catch {
+    return undefined;
+  }
+
+  const host = url.hostname.replace(/^www\./, '');
+  let candidate = null;
+
+  if (host === 'youtu.be') {
+    candidate = url.pathname.slice(1);
+  } else if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'youtube-nocookie.com') {
+    candidate = url.pathname === '/watch'
+      ? url.searchParams.get('v')
+      : url.pathname.match(/^\/(?:embed|shorts|live|v)\/([^/?#]+)/)?.[1] ?? null;
+  }
+
+  return candidate && ID_PATTERN.test(candidate) ? candidate : undefined;
+}
+
+async function fetchOEmbed(id) {
+  const endpoint = `https://www.youtube.com/oembed?url=${encodeURIComponent(
+    `https://www.youtube.com/watch?v=${id}`
+  )}&format=json`;
+  const res = await fetch(endpoint);
+  if (!res.ok) throw new Error(`oEmbed returned ${res.status} — is the video public?`);
+  return res.json();
+}
+
+async function fetchDescription(id) {
+  // A browser User-Agent is required; without one YouTube serves the consent
+  // or nav-only shell that has no player JSON in it.
+  const res = await fetch(`https://www.youtube.com/watch?v=${id}`, {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+      'Accept-Language': 'en-US,en;q=0.9',
+    },
+  });
+  if (!res.ok) throw new Error(`watch page returned ${res.status}`);
+  const html = await res.text();
+
+  const match = html.match(/"shortDescription":"((?:[^"\\]|\\.)*)"/);
+  if (!match) throw new Error('no shortDescription in the watch page — YouTube may have changed its markup');
+  return JSON.parse(`"${match[1]}"`);
+}
+
+/**
+ * Docs URLs in the description, in order, deduplicated.
+ *
+ * These are CANDIDATES, not a placement instruction: descriptions list related
+ * reading, so a video whose home is one article routinely links five.
+ */
+export function extractDocsLinks(description) {
+  const seen = new Set();
+  const links = [];
+  const re = /https?:\/\/adapty\.io\/docs\/([\w-]+(?:\/[\w-]+)*)\/?(?:[?#][^\s)]*)?/g;
+  for (const m of description.matchAll(re)) {
+    const slug = m[1].replace(/\/$/, '');
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    // Whether the link sat under a "Docs:" heading or was mentioned in passing
+    // is a weak signal, but a real one — record it rather than flatten it away.
+    const preceding = description.slice(0, m.index);
+    const underDocsHeading = /(^|\n)\s*Docs:\s*\n[^]*$/i.test(preceding)
+      && !/(^|\n)\s*(Watch next|Timestamps|What you'll learn|Need help)\s*:?\s*\n[^]*$/i.test(
+        preceding.slice(preceding.search(/(^|\n)\s*Docs:/i))
+      );
+    links.push({ slug, url: m[0], underDocsHeading });
+  }
+  return links;
+}
+
+export async function videoMeta(input) {
+  const id = extractVideoId(input);
+  if (!id) throw new Error(`Not a YouTube video ID or URL: ${input}`);
+
+  const warnings = [];
+  const oembed = await fetchOEmbed(id);
+
+  let description = null;
+  try {
+    description = await fetchDescription(id);
+  } catch (err) {
+    warnings.push(
+      `Could not read the description (${err.message}). ` +
+        `Placement must not be guessed from the title alone — ask for the description, ` +
+        `or open https://www.youtube.com/watch?v=${id} and paste it in.`
+    );
+  }
+
+  return {
+    id,
+    title: oembed.title,
+    channel: oembed.author_name,
+    watchUrl: `https://youtu.be/${id}`,
+    description,
+    docsLinks: description ? extractDocsLinks(description) : [],
+    warnings,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const inputs = process.argv.slice(2);
+  if (!inputs.length) {
+    console.error('usage: node yt-meta.mjs <url-or-id> [more...]');
+    process.exit(1);
+  }
+  const results = [];
+  for (const input of inputs) {
+    try {
+      results.push(await videoMeta(input));
+    } catch (err) {
+      results.push({ input, error: err.message });
+      process.exitCode = 1;
+    }
+  }
+  console.log(JSON.stringify(results.length === 1 ? results[0] : results, null, 2));
+}

--- a/src/content/docs/version-3.0/onboarding-actions.mdx
+++ b/src/content/docs/version-3.0/onboarding-actions.mdx
@@ -12,6 +12,8 @@ Each interaction follows a three-part chain:
 2. **Trigger**: The event that activates the logic, such as a tap, an element appearance, or a form submission.
 3. **Action**: The task the flow performs in response. A single trigger can run multiple actions in sequence.
 
+<YouTube id="uicKwOak-Zo" title="Interaction basics" />
+
 ## Set up interactions
 
 To set up an interaction:


### PR DESCRIPTION
Follows the `<YouTube>` component PR. Two things: a skill that publishes a video into the docs, and its first run.

## The skill

`.claude/skills/youtube-video/` — give it a YouTube link in any shape and it finds the article the video belongs in, inserts the embed, and opens a PR.

The mechanical half of this job is already solved by `<YouTube>`. The half that isn't is **picking the article**, so that's what the skill is mostly about. A description's `Docs:` block is *related reading*, not a placement instruction — this video links five articles and belongs in one. The skill seeds candidates from those links, resolves ownership through `context-mill` (per CLAUDE.md, not by grepping the docs), and **stops for confirmation before editing anything**, naming the rejected candidates with reasons.

`yt-meta.mjs` fetches the title and description. WebFetch can't do this — YouTube serves it a navigation-only shell, and it reports the description as *absent* rather than *unreadable*, which is the failure mode most likely to put a video in the wrong article. The helper uses oEmbed for the title and the watch page's player JSON for the description. The second source is undocumented; when it breaks, the helper says so rather than returning an empty description.

## The video

"Interaction basics" (`uicKwOak-Zo`) → top of **Actions**, before `## Set up interactions`.

The `flow-logic` zone brief names this article canon for actions, conditional actions, and custom actions. The video covers the article's whole scope — all trigger types, every action group, sequencing, custom actions — rather than one section, which is what puts it at the top rather than under a heading. Its subject is also the chain the article's intro already spells out: element, trigger, action.

Rejected candidates, all five from the description:

| Candidate | Why not |
|---|---|
| `onboarding-element-visibility` | Already carries `3w3YSOmI3tQ` on its own subject; visibility appears here as one action group |
| `onboarding-navigation-branching` | Already carries `OLl-WziDMhU`, its own navigation video |
| `onboarding-variables` | "Set variable" is one action among many; the video doesn't teach variables |
| `handle-paywall-actions` | SDK-side article about app code receiving actions; this is a builder tutorial |

This makes three videos in the article. The other two sit under `### Show/hide elements` and `## Conditional actions`, so the tiering is overview-at-top, specifics-in-sections.

## Verification

- `check-mdx-parse` (6034 files) and `lint-mdx` both clean
- Rendered page serves three embeds, no stray iframes, `?si=` stripped, and the new one carries `title="Interaction basics"` instead of the generic default
- The `.md` export strips it, as intended
- `lint-prose` flags two lines in this article, both pre-existing and untouched here