### PR TITLE
fix: correct the clone directory in the Copilot CLI and Codex install commands

### DIFF
--- a/src/components/reusable/AdaptySdkIntegrationSkill.mdx
+++ b/src/components/reusable/AdaptySdkIntegrationSkill.mdx
@@ -21,7 +21,7 @@ claude plugin install adapty-skills@adapty
 
 ```
 git clone https://github.com/adaptyteam/adapty-skills.git
-cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/
+cp -r adapty-skills/skills/* ~/.copilot/skills/
 ```
 
 **Gemini CLI**

--- a/src/data/agent-tools.json
+++ b/src/data/agent-tools.json
@@ -14,7 +14,7 @@
             "label": "Copilot CLI",
             "commands": [
                 "git clone https://github.com/adaptyteam/adapty-skills.git",
-                "cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/"
+                "cp -r adapty-skills/skills/* ~/.copilot/skills/"
             ]
         },
         {
@@ -29,7 +29,7 @@
             "label": "Codex",
             "commands": [
                 "git clone https://github.com/adaptyteam/adapty-skills.git",
-                "cp -r adapty-sdk-integration-skill/skills/* ~/.agents/skills/"
+                "cp -r adapty-skills/skills/* ~/.agents/skills/"
             ]
         },
         {


### PR DESCRIPTION
The install commands for Copilot CLI and Codex clone `adapty-skills.git`, which creates a directory named `adapty-skills/` — but the copy step that follows points at `adapty-sdk-integration-skill/`, the repository's former name. The `cp` fails for everyone who follows them.

```bash
git clone https://github.com/adaptyteam/adapty-skills.git
cp -r adapty-sdk-integration-skill/skills/* ~/.copilot/skills/   # no such directory
```

Three lines changed, in the two places that carry these commands:

- `src/data/agent-tools.json` — feeds the **Install agent tools** modal (Copilot CLI and Codex entries)
- `src/components/reusable/AdaptySdkIntegrationSkill.mdx` — restates the same commands as prose, and renders on all seven `adapty-sdk-integration-skill*` pages

The Claude Code, Gemini CLI, and Any tool commands were already correct and are untouched.

The seven translated copies under `src/locales/*/reusable/` carry the same stale path. They are left alone deliberately — the translation workflow regenerates them from this English source on the next push to `main`.