### PR TITLE
docs: add the August 2026 What's new section

### DIFF
--- a/src/content/docs/release-notes/whats-new.mdx
+++ b/src/content/docs/release-notes/whats-new.mdx
@@ -12,6 +12,30 @@ Have feedback on new features?
 We'd love to hear from you! Contact us via the [Product feedback board](https://adapty.featurebase.app/en?b=69831ba5e82e7a3391632ec2).
 :::
 
+## August 2026
+
+- **Retention Messaging**: Show subscribers a custom message on the iOS **Cancel Subscription** screen, right before they confirm the cancellation. Write, localize, and test messages in the Adapty Dashboard, and Adapty answers Apple's Retention Messaging API for you — no backend, no app release. [Learn more](retention-messaging)
+
+- **AI Editor in the Flow Builder**: Describe a change in plain language, and Adapty rewrites, restyles, or rearranges the flow screen you're editing. Adapty tells you what changed, and **Undo** reverts every change from a prompt together. [Learn more](flow-ai-editor)
+
+- **Agent skill for working with flows**: Install the experimental flow-generator skill, and your AI coding tool builds and edits flows through the Adapty CLI. Author a flow from a description or a screenshot, or take a working flow into a new language. [Learn more](flow-generator-skill)
+
+- **iOS, Android, and Unity SDK 4.1**: Adapty Attribution is now opt-in — enable it when you activate the SDK, or installs stop registering. The release also renames the external attribution APIs, and iOS regains support for App Store promoted purchases. Unity 4.1 is the first stable 4.x release, so 3.x projects migrate straight to it. [iOS](migration-to-ios-sdk-41) | [Android](migration-to-android-sdk-41) | [Unity](migration-to-unity-sdk-v4)
+
+- **Convert a legacy paywall into a flow**: The **Move to new builder** action recreates a Paywall Builder paywall as a draft flow, carrying over the layout, the copy in every locale, and the products. Your original paywall stays live while you edit and test the flow. The legacy Paywall Builder and Onboarding Builder are deprecated on October 1, 2026. Published paywalls and onboardings keep working and stay editable, but you can't create new ones. [Convert a paywall](convert-paywall-to-flow) | [Deprecation details](paywall-onboarding-builder-deprecation)
+
+- **Flow screen view events**: The SDK now reports a `flow_screen_showed` event every time a user opens a flow screen. Forward it to Amplitude, Mixpanel, or whichever product analytics you run, and analyze flow screens alongside the rest of your app's events. [iOS](ios-flow-screen-views) | [Android](android-flow-screen-views) | [React Native](react-native-flow-screen-views) | [Flutter](flutter-flow-screen-views) | [Unity](unity-flow-screen-views) | [Kotlin Multiplatform](kmp-flow-screen-views) | [Capacitor](capacitor-flow-screen-views)
+
+- **Keyword Suggester and Search Popularity in Adapty Ads Manager**: Two keyword research tools built on Apple's own data. Keyword Suggester expands a seed phrase into related App Store search phrases and category context. Search Popularity ranks the top search terms for a chosen market, category, and completed week or month. [Keyword Suggester](ads-manager-keyword-suggester) | [Search Popularity](ads-manager-search-popularity)
+
+- **Ads Manager in the Developer CLI**: Manage your Apple Ads account from the terminal under the `adapty asa` topic — campaigns, ad groups, keywords, ads, product pages, automation rules, metrics, and competitor research. Use it to give an AI agent live access to your ad performance, or add hundreds of keywords from a file. [Learn more](developer-cli-ads-manager)
+
+- **Stripe and Paddle in Adapty Attribution**: Connect your Stripe or Paddle account to attribute web-funnel purchases to the ads that drove them. Purchases, renewals, refunds, and chargebacks appear in Adapty Attribution analytics, and conversion events go back to your ad networks. [Stripe](ua-stripe) | [Paddle](ua-paddle)
+
+- **Qualified trials for Meta and TikTok**: Hold a trial event for 1 to 24 hours so your pixel receives only the trials users kept. Adapty sends the event when the hold ends, and only if auto-renewal is still on. Adapty uses the original trial start time, so the network reports the trial on the day it started. [Meta](ua-facebook#qualified-trial) | [TikTok](ua-tiktok#qualified-trial)
+
+- **Stripe Payment Links**: Sell through a Payment Link with no backend by passing your user ID in the link's `client_reference_id` query parameter. Set **Profile creation behavior** to **Use client_reference_id** in **App Settings → Stripe**, and Adapty matches the purchase to the right profile. [Learn more](stripe#payment-links-no-code)
+
 ## July 2026
 
 - **Virtual currencies**: Define in-app currencies like tokens, coins or gems, grant and track a balance for each user, and read those balances from your server through the server-side API. [Learn more](virtual-currencies)


### PR DESCRIPTION
Adds the August 2026 section to **What's new**, inserted above July and below the feedback callout. No existing section was modified.

## What's featured

Eleven bullets, drawn from the 105 non-translation commits that landed on `main` in August:

- **Retention Messaging** — custom messages on the iOS Cancel Subscription screen
- **AI Editor in the Flow Builder** — prompt-driven screen edits
- **Agent skill for working with flows** — the experimental flow-generator skill
- **iOS, Android, and Unity SDK 4.1** — Adapty Attribution becomes opt-in; Unity's first stable 4.x
- **Convert a legacy paywall into a flow** — the Move to new builder action, plus the legacy-builder deprecation date
- **Flow screen view events** — `flow_screen_showed` across all seven platforms
- **Keyword Suggester and Search Popularity** in Adapty Ads Manager
- **Ads Manager in the Developer CLI** — the `adapty asa` topic
- **Stripe and Paddle in Adapty Attribution**
- **Qualified trials for Meta and TikTok**
- **Stripe Payment Links**

Every claim was verified against the article it links to, not against commit messages.

## What was left out

Doc-correctness commits, tooling and CI changes, and the auto-translation churn. Also excluded after review: the Adapty Mail restructure, the PostHog article overhaul, the cohort analytics rework, the SDK 4.0.x patch notes, the docs redesign, and several smaller Flow Builder additions (copy/archive/filter flows, recipes, the Common issues page).

## Verification

- `check-mdx-parse` and `lint-mdx` — clean
- `check-links-diff` — 125 links, 0 broken, 0 stale, including the two section anchors
- `lint-prose` — no new candidates in the added section beyond one `sends` whose destination is named in the preceding sentence

## Worth a reviewer's eye

The converter bullet states **October 1, 2026** as the legacy Paywall Builder and Onboarding Builder deprecation date, taken from the deprecation article. It's the only forward-looking date in the section — please confirm it hasn't moved.

`src/locales/**` is untouched; translations regenerate on push to `main`.