### PR TITLE
docs: add the flow variables video to the Variables article

### DIFF
--- a/src/content/docs/version-3.0/onboarding-variables.mdx
+++ b/src/content/docs/version-3.0/onboarding-variables.mdx
@@ -14,6 +14,8 @@ To open the variable panel, click the **&#123; &#125;** icon in the left panel. 
 - **[Product](#product-variables)**: Built-in variables that pull localized product and offer data from the store.
 - **[Element](#element-variables)**: Variables bound to element states on the canvas.
 
+<YouTube id="sbBxrJoNI1M" title="Work with flow variables" />
+
 ## Custom variables
 
 ### Create a custom variable


### PR DESCRIPTION
Publishes the "Work with flow variables" video (`sbBxrJoNI1M`) into the docs.

## Where

`src/content/docs/version-3.0/onboarding-variables.mdx` — after the intro block, before `## Custom variables`.

## Why this article

The video's four chapters map onto this article's structure one-to-one: product variables, element variables, custom variables, and changing a value with the **Set variable** action. This is where variables are defined rather than referenced, and it carried no video yet, so a whole-subject embed at the top is the right form.

## Candidates rejected

The video description lists five docs links as related reading. Four of them already carry their own video on their own subject:

- `paywall-product-block` — already carries `LLIZCd94PlE` ("Set up purchases in flows"), which the description itself lists as a separate "watch next"
- `onboarding-quizzes` — already carries `o27JCZpziVo`; this video uses a quiz answer only as the example input for a variable
- `flow-selectable-elements` — already carries `btpZPOm9VRY`, also a "watch next"
- `onboarding-text` — no video, but the article owns text styling; this video touches text only as a place a variable lands

Also considered:

- `onboarding-actions` — owns the **Set variable** action covered at 02:48, but already carries three embeds, one of them the conditional-logic video this description points to next