### PR TITLE
docs: custom paywalls are outside the builder deprecation

### DIFF
--- a/.claude/context-mill/zones/flow-logic.md
+++ b/.claude/context-mill/zones/flow-logic.md
@@ -236,6 +236,20 @@ or developer can see and click.
   `placement-metrics.mdx`, `results-and-metrics.mdx`, and `webhook-event-types-and-fields.mdx` in one
   pass — mostly outside flow-logic, but a new revenue/proceeds/webhook field belongs in `flow-metrics`
   too whenever it lands in that cluster.
+- **The builder-deprecation fact is stated in four places, and a correction has to visit all of them.**
+  `grep -rn "October 1, 2026" src/content/docs src/components` returns exactly four hosts:
+  `paywall-onboarding-builder-deprecation` (the canon), the `BuilderDeprecation` reusable, the opening
+  `:::warning` of `migrate-to-flows`, and one bullet in `release-notes/whats-new`. The reusable then
+  multiplies its copy across five legacy articles — `grep -rln BuilderDeprecation src/content/docs` gives
+  `adapty-paywall-builder`, `create-onboarding`, `design-onboarding`, `onboardings` and
+  `quickstart-paywalls`, all in `paywalls-legacy`/`onboardings-legacy` — so one wording change lands on
+  seven reader-facing pages across three zones. **The absence of this rule already cost a ten-day
+  contradiction.** PR #511 (`0f53a8e8c`, 2026-08-18, "legacy builders keep editing after deprecation,
+  only creation and support end") changed the canon to say editing survives, and `git show --stat
+  0f53a8e8c` confirms it touched that one file — so the reusable and `migrate-to-flows` went on telling
+  readers the builders become "read-only: you can't create or edit" until they were corrected 2026-08-28.
+  `whats-new` was the one secondary copy that happened to already be right. Grep the **date**, never a
+  phrase: the four copies share no sentence, so a wording-based search finds at most one of them.
 
 ## Boundaries
 

--- a/src/components/reusable/BuilderDeprecation.mdx
+++ b/src/components/reusable/BuilderDeprecation.mdx
@@ -4,5 +4,5 @@ no_index: true
 import Callout from '../Callout.astro';
 
 <Callout type="warning">
-From October 1, 2026, the legacy Paywall Builder and Onboarding Builder are read-only: you can't create or edit paywalls and onboardings in them, and their support stops. Published paywalls and onboardings keep working in your apps. Build new ones in [Flow Builder](adapty-flow-builder) — see [Paywall Builder and Onboarding Builder deprecation](paywall-onboarding-builder-deprecation) for what changes.
+From October 1, 2026, you can't create new paywalls and onboardings in the legacy Paywall Builder and Onboarding Builder, and their support stops. Published paywalls and onboardings keep working in your apps, and you can still edit them. Build new ones in [Flow Builder](adapty-flow-builder) — see [Paywall Builder and Onboarding Builder deprecation](paywall-onboarding-builder-deprecation) for what changes.
 </Callout>

--- a/src/content/docs/guides/flow-builder/migrate-to-flows.mdx
+++ b/src/content/docs/guides/flow-builder/migrate-to-flows.mdx
@@ -9,7 +9,7 @@ import CustomDocCardList from '@site/src/components/CustomDocCardList';
 In Adapty, a *flow* combines an onboarding and a paywall into a single entity behind one placement. A flow replaces the separate onboarding and paywall that you build and serve on their own.
 
 :::warning
-From October 1, 2026, you can't create or edit paywalls and onboardings in the legacy builders, and their support stops. Everything you already have keeps working — see [what changes on that date](paywall-onboarding-builder-deprecation).
+From October 1, 2026, you can't create new paywalls and onboardings in the legacy builders, and their support stops. Everything you already have keeps working and stays editable — see [what changes on that date](paywall-onboarding-builder-deprecation).
 :::
 
 This guide explains what changes when you move to flows, and how to roll the change out without disrupting users on older app versions.

--- a/src/content/docs/guides/flow-builder/paywall-onboarding-builder-deprecation.mdx
+++ b/src/content/docs/guides/flow-builder/paywall-onboarding-builder-deprecation.mdx
@@ -21,6 +21,12 @@ From that date, in the legacy builders:
 - **No new paywalls or onboardings**: You can't create them in the legacy builders. Build new ones in [Flow Builder](adapty-flow-builder).
 - **No support**: Adapty no longer ships fixes for the legacy builders.
 
+## Custom paywalls stay available
+
+The deprecation covers the two visual builders, not the paywall itself. If you build your paywall UI in your own app code and use Adapty as the purchase infrastructure, the deprecation doesn't apply to you.
+
+You keep creating [paywalls](paywalls) to define which products you sell, and assigning them to placements. You can still add an optional [remote config](customize-paywall-with-remote-config) to a paywall to change copy and media without an app release. Your app fetches the paywall's products and calls `makePurchase` — see <InlineTooltip tooltip="Render your own paywall UI and delegate purchases to Adapty">[iOS](ios-implement-paywalls-manually), [Android](android-implement-paywalls-manually), [React Native](react-native-implement-paywalls-manually), [Flutter](flutter-implement-paywalls-manually), [Unity](unity-implement-paywalls-manually), [Kotlin Multiplatform](kmp-implement-paywalls-manually), and [Capacitor](capacitor-implement-paywalls-manually)</InlineTooltip>.
+
 ## Move to Flow Builder
 
 A [flow](adapty-flow-builder) combines onboarding screens and a paywall into one experience, built in one editor and served from one placement — a new flow placement, because a flow is a different content type from the paywall or onboarding it replaces. For the whole path — build the flow, preview it on a device, create a flow placement, and update your app to Adapty SDK v4 — follow [Migrate to flows](migrate-to-flows).


### PR DESCRIPTION
The deprecation article explains what happens to paywalls and onboardings built in the two visual builders, but it never said what happens to a paywall a developer renders in their own app code — using Adapty only as the purchase infrastructure. Readers on that path have no way to tell from the page whether October 1, 2026 applies to them.

## Changes

**A new "Custom paywalls stay available" section** in `paywall-onboarding-builder-deprecation`, placed after the stop list so a developer who has just read what ends learns they don't need the migration section below it. It states that the deprecation is scoped to the visual builders, not the paywall entity: paywalls stay a container for the products you sell, remote config stays optional on them, and `makePurchase` is still the purchase path. Links out to all seven `implement-paywalls-manually` guides.

"Custom paywall" is the docs' existing term for this, not a new one — `create-paywall` already contrasts **Paywall Builder** against **Custom paywall**.

**Two stale copies of the deprecation fact, corrected.** Commit `0f53a8e8c` changed the canonical article to say editing survives the deprecation, but touched only that file. Two secondary copies went on saying the builders become read-only:

- `BuilderDeprecation.mdx` — the callout rendered on `adapty-paywall-builder`, `create-onboarding`, `design-onboarding`, `onboardings`, and `quickstart-paywalls`
- the opening `:::warning` of `migrate-to-flows`

Both now match the canon. The fourth copy, a bullet in `release-notes/whats-new`, was already correct and is unchanged.

**A ripple rule** in the `flow-logic` zone brief recording that this fact lives in four places which share no sentence, so a wording-based grep finds at most one — grep the date instead.

## Verification

- `check-mdx-parse` — 6130 files parsed cleanly
- `lint-mdx` — all files OK
- `lint-prose` — clean on both edited articles
- `check-links` — 12 broken links reported, all pre-existing and none in these files; all 9 link targets added here resolve to real articles
- `mill:status` — no new validation or dangling-id errors; `reviewed_at` deliberately left at 2026-08-10

## Worth a reviewer's eye

That custom paywalls survive the deprecation is a product-intent claim, confirmed by @eandreeva-twr rather than derived from code — no future date is fixed anywhere in the source. What is mechanically checkable is that it's coherent: `PaywallResponse` in `adapty-api.yaml` carries `use_paywall_builder` as its own boolean, so a no-builder paywall never depended on the builder, and `AdaptyFlow.paywalls` means products still reach the app through a paywall object on SDK v4.
